### PR TITLE
Refactor skill CLI to use runtime service

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ curl -H "X-AdaOS-Token: dev-local-token" -H "Content-Type: application/json" \
 adaos monitor sse http://127.0.0.1:8777/api/observe/stream?replay_lines=50 --topic net.subnet.
 ```
 
+```python
+from adaos.services.skill.runtime import run_skill_handler_sync
+
+print(
+    run_skill_handler_sync(
+        "weather_skill",
+        "nlp.intent.weather.get",
+        {"city": "Berlin"},
+    )
+)
+```
+
 ### Сменить роль ноды
 
 ```python

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -12,3 +12,12 @@ adaos api serve --host 127.0.0.1 --port 8777
 ```bash
 adaos skill run weather_skill weather.get --event --entities '{"city":"Berlin"}'
 ```
+
+Сервисный модуль `adaos.services.skill.runtime` предоставляет те же операции для
+программного использования из Python.
+
+```python
+from adaos.services.skill.runtime import run_skill_handler_sync
+
+run_skill_handler_sync("weather_skill", "weather.get", {"city": "Berlin"})
+```

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -101,6 +101,22 @@ adaos skill run weather_skill
 adaos skill run weather_skill --topic nlp.intent.weather.get --payload '{"city": "Berlin"}'
 ```
 
+### Программно из Python
+
+```python
+from adaos.services.skill.runtime import run_skill_handler_sync, run_skill_prep
+
+result = run_skill_handler_sync(
+    "weather_skill",
+    "nlp.intent.weather.get",
+    {"city": "Berlin"},
+)
+print(result)
+
+prep_report = run_skill_prep("weather_skill")
+print(prep_report)
+```
+
 ## Репозитории
 
 ### Моно-репозиторий

--- a/src/adaos/apps/cli/commands/skill.py
+++ b/src/adaos/apps/cli/commands/skill.py
@@ -1,19 +1,24 @@
 # src\adaos\apps\cli\commands\skill.py
 from __future__ import annotations
-import typer
+
 import json
-import asyncio
-import importlib.util
-from adaos.sdk.bus import emit
-from typing import Optional
-import os, traceback
-from pathlib import Path
+import os
+import traceback
+
+import typer
+
 from adaos.sdk.i18n import _
 from adaos.services.agent_context import get_ctx
 from adaos.services.skill.manager import SkillManager
+from adaos.services.skill.runtime import (
+    SkillPrepError,
+    SkillPrepMissingFunctionError,
+    SkillPrepScriptNotFoundError,
+    SkillRuntimeError,
+    run_skill_handler_sync,
+    run_skill_prep,
+)
 from adaos.adapters.db import SqliteSkillRegistry
-from adaos.adapters.skills.git_repo import GitSkillRepository
-from adaos.sdk.context import set_current_skill, get_current_skill
 from adaos.sdk.skills import (
     push as push_skill,
     pull as pull_skill,
@@ -167,48 +172,6 @@ def cmd_install(name: str):
     typer.echo(msg)
 
 
-_MANIFEST_NAMES = ("skill.yaml", "manifest.yaml", "adaos.skill.yaml")
-
-
-def _resolve_skill_dir(skill_name: str) -> Path:
-    """
-    Ищем директорию навыка по имени в каталоге skills_root из контекста.
-    1) <skills_root>/<skill_name>
-    2) Fallback: поиск по подкаталогам с наличием одного из манифестов.
-    """
-    # TODO логику перенести на уровень сервиса
-    ctx = get_ctx()
-    skills_root = Path(ctx.paths.skills_dir())  # ожидается, что в контексте настроено
-    direct = skills_root / skill_name
-    if direct.is_dir():
-        return direct
-
-    # fallback-поиск: skills_root/**/(skill.yaml|manifest.yaml|adaos.skill.yaml)
-    matches = []
-    for p in skills_root.rglob("*"):
-        if p.is_file() and p.name in _MANIFEST_NAMES and p.parent.name == skill_name:
-            matches.append(p.parent)
-
-    if not matches:
-        raise typer.BadParameter(f"Skill '{skill_name}' not найден в {skills_root}. " f"Ожидал {skills_root / skill_name} или подкаталог с манифестом.")
-    if len(matches) > 1:
-        # неоднозначность — просим уточнить
-        found = "\n - " + "\n - ".join(str(m) for m in matches)
-        raise typer.BadParameter(f"Найдено несколько директорий с именем '{skill_name}':{found}\n" f"Уточните путь или переименуйте дубликаты.")
-    return matches[0]
-
-
-def _import_handler(handler_file: Path):
-    spec = importlib.util.spec_from_file_location("skill_handler", handler_file)
-    if spec is None or spec.loader is None:
-        raise typer.BadParameter(f"Не удалось импортировать {handler_file}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    if not hasattr(module, "handle"):
-        raise typer.BadParameter("Файл не содержит функцию handle(topic, payload)")
-    return module.handle
-
-
 @app.command("run")
 def run(
     skill: str = typer.Argument(..., help="Имя навыка (директория в skills_root)"),
@@ -220,17 +183,7 @@ def run(
     Пример:
     adaos skill run weather_skill --topic nlp.intent.weather.get --payload '{"city": "Berlin"}'
     """
-    # TODO логику перенести на уровень сервиса
-    # 1) находим папку навыка через get_ctx()
-    skill_dir = _resolve_skill_dir(skill)
-    handler_path = skill_dir / "handlers" / "main.py"
-    if not handler_path.is_file():
-        raise typer.BadParameter(f"Не найден обработчик: {handler_path}")
-
-    # 2) импортируем handle(topic, payload)
-    handle_fn = _import_handler(handler_path)
-
-    # 3) парсим payload
+    # парсим payload
     try:
         payload_obj = json.loads(payload) if payload else {}
         if not isinstance(payload_obj, dict):
@@ -238,39 +191,31 @@ def run(
     except Exception as e:
         raise typer.BadParameter(f"Некорректный --payload: {e}")
 
-    # 4) вызываем
-    async def main():
-        res = handle_fn(topic, payload_obj)
-        if asyncio.iscoroutine(res):
-            res = await res
-        typer.echo(f"OK: {res!r}")
+    try:
+        result = run_skill_handler_sync(skill, topic, payload_obj)
+    except SkillRuntimeError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
-    asyncio.run(main())
+    typer.echo(f"OK: {result!r}")
 
 
 @app.command("prep")
 def prep_command(skill_name: str):
     """Запуск стадии подготовки (discover) для навыка"""
-    # TODO логику перенести на уровень сервиса
-    set_current_skill(skill_name)
-    ctx = get_ctx()
-    skill_path = ctx.paths.skills_dir() / skill_name
-
-    prep_script = skill_path / "prep" / "prepare.py"
-    if not prep_script.exists():
+    try:
+        result = run_skill_prep(skill_name)
+    except SkillPrepScriptNotFoundError:
         print(f"[red]{_('skill.prep.not_found', skill_name=skill_name)}[/red]")
         raise typer.Exit(code=1)
-
-    # Динамически импортируем prepare.py
-    spec = importlib.util.spec_from_file_location("prepare", prep_script)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-
-    if hasattr(module, "run_prep"):
-        result = module.run_prep(skill_path)
-        if result["status"] == "ok":
-            print(f"[green]{_('skill.prep.success', skill_name=skill_name)}[/green]")
-        else:
-            print(f"[red]{_('skill.prep.failed', reason=result['reason'])}[/red]")
-    else:
+    except SkillPrepMissingFunctionError:
         print(f"[red]{_('skill.prep.missing_func', skill_name=skill_name)}[/red]")
+        raise typer.Exit(code=1)
+    except SkillPrepError as exc:
+        print(f"[red]{_('skill.prep.failed', reason=str(exc))}[/red]")
+        raise typer.Exit(code=1)
+
+    if result.get("status") == "ok":
+        print(f"[green]{_('skill.prep.success', skill_name=skill_name)}[/green]")
+    else:
+        reason = result.get("reason", "unknown")
+        print(f"[red]{_('skill.prep.failed', reason=reason)}[/red]")

--- a/src/adaos/services/skill/runtime.py
+++ b/src/adaos/services/skill/runtime.py
@@ -1,0 +1,253 @@
+"""Utilities for executing local skill code from the AdaOS services layer.
+
+The functions defined here are thin abstractions that encapsulate the
+implementation previously living inside the CLI commands.  Moving them to the
+service level makes them reusable from other entry points (tests, HTTP API,
+etc.) while keeping the CLI focused on argument parsing and formatting the
+output for the user.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from inspect import isawaitable
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from adaos.services.agent_context import AgentContext, get_ctx
+from adaos.services.skill.context import SkillContextService
+
+_MANIFEST_NAMES = ("skill.yaml", "manifest.yaml", "adaos.skill.yaml")
+
+
+class SkillRuntimeError(RuntimeError):
+    """Base error for problems while interacting with skill code."""
+
+
+class SkillDirectoryNotFoundError(SkillRuntimeError):
+    """Raised when a skill directory cannot be located on disk."""
+
+
+class SkillDirectoryAmbiguousError(SkillRuntimeError):
+    """Raised when multiple directories match the requested skill name."""
+
+
+class SkillHandlerError(SkillRuntimeError):
+    """Base class for handler-related problems."""
+
+
+class SkillHandlerNotFoundError(SkillHandlerError):
+    """Raised when ``handlers/main.py`` is missing."""
+
+
+class SkillHandlerImportError(SkillHandlerError):
+    """Raised when the handler module cannot be imported."""
+
+
+class SkillHandlerMissingFunctionError(SkillHandlerError):
+    """Raised when the handler module does not expose ``handle``."""
+
+
+class SkillPrepError(SkillRuntimeError):
+    """Raised when the preparation stage cannot be executed."""
+
+
+class SkillPrepScriptNotFoundError(SkillPrepError):
+    """Raised when ``prep/prepare.py`` is missing."""
+
+
+class SkillPrepImportError(SkillPrepError):
+    """Raised when the preparation script cannot be imported."""
+
+
+class SkillPrepMissingFunctionError(SkillPrepError):
+    """Raised when ``run_prep`` is not defined in ``prepare.py``."""
+
+
+def find_skill_dir(skill_name: str, *, ctx: Optional[AgentContext] = None) -> Path:
+    """Locate the directory with the skill sources inside ``skills_root``.
+
+    The lookup is performed in two stages:
+
+    1. Direct lookup by ``<skills_root>/<skill_name>``
+    2. Fallback search for ``<skills_root>/**/<skill_name>`` that contains one
+       of the known manifest files.
+
+    Args:
+        skill_name: Identifier of the skill (normally matches the directory
+            name inside the monorepo checkout).
+        ctx: Optional context override.  If omitted the global agent context is
+            used via :func:`~adaos.services.agent_context.get_ctx`.
+
+    Returns:
+        ``Path`` pointing to the directory with the skill sources.
+
+    Raises:
+        SkillDirectoryNotFoundError: if no directory can be located.
+        SkillDirectoryAmbiguousError: if more than one candidate is found.
+    """
+
+    agent_ctx = ctx or get_ctx()
+    skills_root = Path(agent_ctx.paths.skills_dir())
+
+    direct = skills_root / skill_name
+    if direct.is_dir():
+        return direct
+
+    matches = []
+    for path in skills_root.rglob("*"):
+        if path.is_file() and path.name in _MANIFEST_NAMES and path.parent.name == skill_name:
+            matches.append(path.parent)
+
+    if not matches:
+        raise SkillDirectoryNotFoundError(
+            f"Skill '{skill_name}' was not found under {skills_root}"
+        )
+
+    if len(matches) > 1:
+        found = "\n - " + "\n - ".join(str(match) for match in matches)
+        raise SkillDirectoryAmbiguousError(
+            f"Multiple directories match skill '{skill_name}':{found}\n"
+            "Please disambiguate by renaming duplicates or specifying a path."
+        )
+
+    return matches[0]
+
+
+def _load_handler(handler_file: Path):
+    spec = importlib.util.spec_from_file_location("adaos_skill_handler", handler_file)
+    if spec is None or spec.loader is None:
+        raise SkillHandlerImportError(f"Failed to import handler from {handler_file}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+
+    handle_fn = getattr(module, "handle", None)
+    if handle_fn is None:
+        raise SkillHandlerMissingFunctionError(
+            "Handler module does not define handle(topic, payload)"
+        )
+
+    return handle_fn
+
+
+async def run_skill_handler(
+    skill_name: str,
+    topic: str,
+    payload: Mapping[str, Any],
+    *,
+    ctx: Optional[AgentContext] = None,
+) -> Any:
+    """Execute the ``handle`` function of a skill handler.
+
+    Args:
+        skill_name: Name of the skill to execute.
+        topic: Event topic/intention passed to the handler.
+        payload: JSON-like mapping that represents the payload.
+        ctx: Optional context override.
+
+    Returns:
+        Whatever value the handler returns.
+
+    Raises:
+        SkillDirectoryNotFoundError: If the skill cannot be located.
+        SkillDirectoryAmbiguousError: If multiple directories match the skill.
+        SkillHandlerImportError: If the handler file is missing or invalid.
+    """
+
+    agent_ctx = ctx or get_ctx()
+    skill_dir = find_skill_dir(skill_name, ctx=agent_ctx)
+    handler_path = skill_dir / "handlers" / "main.py"
+
+    if not handler_path.is_file():
+        raise SkillHandlerNotFoundError(f"Handler file not found: {handler_path}")
+
+    handle_fn = _load_handler(handler_path)
+
+    result = handle_fn(topic, payload)
+    if isawaitable(result):
+        result = await result
+    return result
+
+
+def run_skill_handler_sync(
+    skill_name: str,
+    topic: str,
+    payload: Mapping[str, Any],
+    *,
+    ctx: Optional[AgentContext] = None,
+) -> Any:
+    """Synchronously execute :func:`run_skill_handler`.
+
+    This helper provides a convenient wrapper that can be used from synchronous
+    contexts (like CLI commands).  It automatically manages the event loop by
+    delegating to :func:`asyncio.run` when needed.  When executed inside an
+    already running loop an explicit ``RuntimeError`` is raised to prevent
+    accidental nested event loops.
+    """
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(run_skill_handler(skill_name, topic, payload, ctx=ctx))
+    raise RuntimeError("run_skill_handler_sync() cannot be used inside an active event loop")
+
+
+def run_skill_prep(skill_name: str, *, ctx: Optional[AgentContext] = None) -> Mapping[str, Any]:
+    """Execute the ``prepare.py`` helper for a given skill.
+
+    Args:
+        skill_name: Name of the skill.
+        ctx: Optional context override.
+
+    Returns:
+        The dictionary returned by ``run_prep`` inside ``prepare.py``.
+
+    Raises:
+        SkillPrepError: For any issue related to locating or executing the
+            preparation script.
+    """
+
+    agent_ctx = ctx or get_ctx()
+    SkillContextService(agent_ctx).set_current_skill(skill_name)
+
+    skill_dir = find_skill_dir(skill_name, ctx=agent_ctx)
+    prep_script = skill_dir / "prep" / "prepare.py"
+
+    if not prep_script.exists():
+        raise SkillPrepScriptNotFoundError(
+            f"Preparation script not found for skill '{skill_name}'"
+        )
+
+    spec = importlib.util.spec_from_file_location("adaos_skill_prep", prep_script)
+    if spec is None or spec.loader is None:
+        raise SkillPrepImportError(f"Unable to import preparation script: {prep_script}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+
+    run_prep = getattr(module, "run_prep", None)
+    if run_prep is None:
+        raise SkillPrepMissingFunctionError(f"run_prep() is not defined in {prep_script}")
+
+    return run_prep(skill_dir)
+
+
+__all__ = [
+    "SkillRuntimeError",
+    "SkillDirectoryNotFoundError",
+    "SkillDirectoryAmbiguousError",
+    "SkillHandlerError",
+    "SkillHandlerNotFoundError",
+    "SkillHandlerImportError",
+    "SkillHandlerMissingFunctionError",
+    "SkillPrepError",
+    "SkillPrepScriptNotFoundError",
+    "SkillPrepImportError",
+    "SkillPrepMissingFunctionError",
+    "find_skill_dir",
+    "run_skill_handler",
+    "run_skill_handler_sync",
+    "run_skill_prep",
+]

--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -1,0 +1,121 @@
+"""Tests for the reusable skill runtime helpers."""
+
+from __future__ import annotations
+
+import textwrap
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from adaos.services.agent_context import get_ctx
+from adaos.services.skill.runtime import (
+    SkillDirectoryNotFoundError,
+    SkillPrepScriptNotFoundError,
+    find_skill_dir,
+    run_skill_handler_sync,
+    run_skill_prep,
+)
+
+
+@pytest.fixture
+def skill_factory() -> Callable[[str], Path]:
+    """Create skills under the current ``skills_dir`` for runtime tests."""
+
+    def _create_skill(
+        name: str,
+        *,
+        handler_source: str | None = None,
+        prep_source: str | None = textwrap.dedent(
+            """
+            from pathlib import Path
+
+            def run_prep(skill_path: Path):
+                return {"status": "ok"}
+            """
+        ),
+    ) -> Path:
+        ctx = get_ctx()
+        root = Path(ctx.paths.skills_dir())
+        skill_dir = root / name
+        (skill_dir / "handlers").mkdir(parents=True, exist_ok=True)
+        (skill_dir / "manifest.yaml").write_text(
+            textwrap.dedent(
+                f"""
+                id: {name}
+                name: {name}
+                version: 0.0.1
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        handler_source = handler_source or textwrap.dedent(
+            """
+            def handle(topic, payload):
+                return {"topic": topic, "payload": payload}
+            """
+        )
+        (skill_dir / "handlers" / "main.py").write_text(handler_source, encoding="utf-8")
+
+        if prep_source is not None:
+            (skill_dir / "prep").mkdir(parents=True, exist_ok=True)
+            (skill_dir / "prep" / "prepare.py").write_text(prep_source, encoding="utf-8")
+
+        return skill_dir
+
+    return _create_skill
+
+
+def test_find_skill_dir_returns_direct_path(skill_factory):
+    skill_dir = skill_factory("demo_skill")
+    assert find_skill_dir("demo_skill").resolve() == skill_dir.resolve()
+
+
+def test_find_skill_dir_missing_raises():
+    with pytest.raises(SkillDirectoryNotFoundError):
+        find_skill_dir("does_not_exist")
+
+
+def test_run_skill_handler_sync_handles_coroutines(skill_factory):
+    handler_source = textwrap.dedent(
+        """
+        import asyncio
+
+        async def handle(topic, payload):
+            await asyncio.sleep(0)
+            return {"topic": topic, "payload": payload, "status": "ok"}
+        """
+    )
+    skill_factory("async_skill", handler_source=handler_source, prep_source=None)
+
+    result = run_skill_handler_sync("async_skill", "demo.topic", {"foo": "bar"})
+    assert result == {"topic": "demo.topic", "payload": {"foo": "bar"}, "status": "ok"}
+
+
+def test_run_skill_prep_executes_script(skill_factory):
+    prep_source = textwrap.dedent(
+        """
+        from pathlib import Path
+
+        def run_prep(skill_path: Path):
+            artifact = skill_path / "prep" / "artifact.txt"
+            artifact.write_text("done", encoding="utf-8")
+            return {"status": "ok", "artifact": str(artifact)}
+        """
+    )
+    skill_dir = skill_factory("prep_skill", prep_source=prep_source)
+
+    result = run_skill_prep("prep_skill")
+
+    assert result["status"] == "ok"
+    assert Path(result["artifact"]).read_text(encoding="utf-8") == "done"
+    assert (skill_dir / "prep" / "artifact.txt").exists()
+
+
+def test_run_skill_prep_missing_script_raises(skill_factory):
+    skill_factory("no_prep", prep_source=None)
+
+    with pytest.raises(SkillPrepScriptNotFoundError):
+        run_skill_prep("no_prep")


### PR DESCRIPTION
## Summary
- add a reusable `adaos.services.skill.runtime` module that locates skills, executes handlers, and runs prep scripts with dedicated exceptions
- refactor the skill CLI commands to delegate runtime actions to the new service layer while keeping argument handling in the CLI
- cover the new service entry points with tests and document the Python APIs in the README and skills documentation

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9668ffc6c833288ef682d69d8ef65