### PR TITLE
feat(sdk): guard runtime access and add i18n fallback

### DIFF
--- a/src/adaos/sdk/_ctx.py
+++ b/src/adaos/sdk/_ctx.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from adaos.services.agent_context import AgentContext, get_ctx
+
+from adaos.sdk.errors import SdkRuntimeNotInitialized
+
+
+def require_ctx(message: str) -> AgentContext:
+    """Return the current :class:`AgentContext` or fail with an SDK-specific error."""
+    try:
+        return get_ctx()
+    except RuntimeError as exc:  # pragma: no cover - defensive wrapper
+        raise SdkRuntimeNotInitialized(message) from exc

--- a/src/adaos/sdk/context.py
+++ b/src/adaos/sdk/context.py
@@ -1,18 +1,25 @@
 from __future__ import annotations
+
 from typing import Optional
 
-from adaos.services.agent_context import get_ctx
 from adaos.services.skill.context import SkillContextService
 from adaos.ports.skill_context import CurrentSkill
 
+from adaos.sdk._ctx import require_ctx
+
+
+def _service() -> SkillContextService:
+    ctx = require_ctx("SDK skill context used before runtime initialization.")
+    return SkillContextService(ctx)
+
 
 def set_current_skill(name: str) -> bool:
-    return SkillContextService(get_ctx()).set_current_skill(name)
+    return _service().set_current_skill(name)
 
 
 def clear_current_skill() -> None:
-    SkillContextService(get_ctx()).clear_current_skill()
+    _service().clear_current_skill()
 
 
 def get_current_skill() -> Optional[CurrentSkill]:
-    return SkillContextService(get_ctx()).get_current_skill()
+    return _service().get_current_skill()

--- a/src/adaos/sdk/errors.py
+++ b/src/adaos/sdk/errors.py
@@ -1,4 +1,13 @@
-class SdkError(RuntimeError): ...
+from __future__ import annotations
 
 
-class BusNotAvailable(SdkError): ...
+class SdkRuntimeNotInitialized(RuntimeError):
+    """Raised when an SDK facade is used before the runtime context is available."""
+
+
+class CapabilityError(PermissionError):
+    """Raised when the current skill lacks required capabilities."""
+
+
+class QuotaExceeded(RuntimeError):
+    """Raised when an operation exceeds an allocated quota."""

--- a/src/adaos/sdk/events.py
+++ b/src/adaos/sdk/events.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from adaos.sdk._ctx import require_ctx
+from adaos.sdk.decorators import _SUBSCRIPTIONS
+
+
+def publish(topic: str, payload: dict, **meta: object) -> None:
+    ctx = require_ctx("SDK events used before runtime initialization.")
+    message = dict(payload)
+    if meta:
+        message |= dict(meta)
+    ctx.bus.publish(topic, message)
+
+
+def subscribe(topic: str) -> Callable[[Callable], Callable]:
+    def decorator(handler: Callable):
+        _SUBSCRIPTIONS.append((topic, handler))
+        return handler
+
+    return decorator

--- a/src/adaos/sdk/i18n.py
+++ b/src/adaos/sdk/i18n.py
@@ -1,28 +1,34 @@
-# src\adaos\sdk\i18n.py
-# Adopted
 from __future__ import annotations
-import os
-from pathlib import Path
-from typing import Optional, Any, Dict
 
-from adaos.services.agent_context import get_ctx
-from adaos.services.i18n.service import I18nService, DEFAULT_LANG
+import json
+import os
+from functools import lru_cache
+from importlib import resources
+from typing import Any, Dict
+
+from adaos.services.i18n.service import DEFAULT_LANG, I18nService
+
+from adaos.sdk._ctx import require_ctx
 from adaos.sdk.context import get_current_skill
+from adaos.sdk.errors import SdkRuntimeNotInitialized
 
 
 class I18n:
-    def __init__(self, lang: Optional[str] = None):
+    """Thin facade over :class:`adaos.services.i18n.service.I18nService`."""
+
+    def __init__(self, lang: str | None = None):
         self.lang = lang or os.getenv("ADAOS_LANG") or DEFAULT_LANG
 
-    def translate(self, key: str, **kwargs) -> str:
-        ctx = get_ctx()
+    def translate(self, key: str, **kwargs: Any) -> str:
+        try:
+            ctx = require_ctx("SDK i18n used before runtime initialization.")
+        except SdkRuntimeNotInitialized:
+            return self._translate_pre_bootstrap(key, **kwargs)
+
         svc = I18nService(ctx)
-
-        cur = get_current_skill()  # ожидаем объект с полями name/path, как у тебя
-        skill_path: Optional[Path] = getattr(cur, "path", None)
-        skill_id: Optional[str] = getattr(cur, "name", None)
-
-        # auto-scope: ключи с 'prep.' — считаем «локаль навыка»
+        current = get_current_skill()
+        skill_path = getattr(current, "path", None)
+        skill_id = getattr(current, "name", None)
         scope = "skill" if key.startswith("prep.") else "global"
 
         return svc.translate(
@@ -34,6 +40,39 @@ class I18n:
             scope=scope,
         )
 
+    def _translate_pre_bootstrap(self, key: str, **kwargs: Any) -> str:
+        messages = self._load_package_messages(self.lang)
+        text = messages.get(key, key)
+        try:
+            return text.format(**kwargs)
+        except Exception:
+            return text
 
-# короткий алиас
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def _load_package_messages(lang: str) -> Dict[str, str]:
+        package = "adaos.locales"
+        candidates = [lang, DEFAULT_LANG]
+        for candidate in candidates:
+            if not candidate:
+                continue
+            resource_name = f"{candidate}.json"
+            try:
+                file = resources.files(package).joinpath(resource_name)
+            except AttributeError:  # pragma: no cover - fallback for legacy importlib
+                try:
+                    with resources.open_text(package, resource_name, encoding="utf-8") as stream:
+                        return json.load(stream)
+                except (FileNotFoundError, json.JSONDecodeError, OSError):
+                    continue
+            else:
+                if file.is_file():
+                    try:
+                        with file.open("r", encoding="utf-8") as stream:
+                            return json.load(stream)
+                    except (FileNotFoundError, json.JSONDecodeError, OSError):
+                        continue
+        return {}
+
+
 _ = I18n().translate


### PR DESCRIPTION
## Summary
- add a require_ctx helper and new SDK error types for runtime validation
- update SDK context and events facades to fail fast before runtime
- enhance the i18n facade with pre-bootstrap locale loading and runtime delegation

## Testing
- PYTHONPATH=src pytest tests/test_decorators_registry.py tests/test_bus_sdk_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68cd2a11b5d08332ad81346cfbb1d324