### PR TITLE
Add SDK control plane facades with capability enforcement

### DIFF
--- a/docs/sdk_control_plane.md
+++ b/docs/sdk_control_plane.md
@@ -1,0 +1,144 @@
+# SDK Control Plane Tools
+
+AdaOS exposes a safe control plane to skills through a curated set of SDK tools.
+These helpers wrap internal services and enforce capability checks, idempotency and
+quota guards so that LLM-powered skills can manage their own lifecycle without
+breaking the host runtime.
+
+## Capabilities overview
+
+Every tool requires an explicit capability token on `ctx.caps`:
+
+| Tool prefix                | Capability token                |
+|---------------------------|---------------------------------|
+| `manage.self.*`           | `manage.self.validate`, `manage.self.state`, `manage.self.update` |
+| `skills.*`                | `manage.skills.install`, `manage.skills.uninstall`, `manage.skills.list` |
+| `scenarios.*`             | `manage.scenarios.toggle`, `manage.scenarios.bind` |
+| `resources.*`             | `manage.resources.request`, `manage.resources.status` |
+
+Missing capabilities raise `CapabilityError` immediately. SDK calls made before
+runtime initialisation raise `SdkRuntimeNotInitialized`.
+
+## Self-management tools (`manage.self.*`)
+
+### `manage.self.validate`
+
+*Purpose:* validate the current skill against static schema and runtime exports.
+
+```json
+{
+  "ok": true,
+  "issues": [
+    {"level": "warning", "code": "tools.missing_export", "message": "...", "where": "tools[]"}
+  ]
+}
+```
+
+Inputs support `strict` and `probe_tools` booleans. The call resolves the
+currently selected skill and delegates to `SkillValidationService`. The issues
+array mirrors the service `ValidationReport`.
+
+### `manage.self.state.get`
+
+Fetch private per-skill state from the KV store under
+`skills/{skill_id}/state/{key}` (or `global/state/...` when no skill is active).
+
+```json
+{
+  "status": "ok",
+  "key": "last_run",
+  "value": {"ts": 1690000000},
+  "found": true
+}
+```
+
+### `manage.self.state.put`
+
+Store/update state with idempotency. The request requires `request_id` and
+supports `dry_run`. Stored results are cached under both
+`requests/manage.self.state.put/{skill}/{request_id}` and
+`skills/{skill}/requests/{request_id}`.
+
+```json
+{
+  "status": "ok",
+  "key": "last_run",
+  "value": {"ts": 1690000000},
+  "stored": true,
+  "dry_run": false,
+  "request_id": "abc",
+  "previous": null,
+  "previous_exists": false
+}
+```
+
+`dry_run=true` performs validation without writing. Repeating a request with the
+same `request_id` returns the cached result.
+
+### `manage.self.update.request`
+
+Request pulling the latest version of the active skill. Results include the
+updated flag and optional version string:
+
+```json
+{"status": "ok", "updated": true, "version": "1.2.3", "dry_run": false, "request_id": "abc"}
+```
+
+If the skill directory is read-only the SDK translates the underlying
+permission error into `CapabilityError`.
+
+## Skill administration (`skills.*`)
+
+Available only to deployments that grant `manage.skills.*` tokens.
+
+* `skills.install(ref, request_id, dry_run=false)` → installs from monorepo or git
+  URL. Idempotent per `request_id`.
+* `skills.uninstall(skill_id, request_id, dry_run=false)` → removes the skill if
+  present, otherwise returns `action: "noop"`.
+* `skills.list()` → returns `{ "skills": [{"id": "demo", "name": "demo", "version": "1.0.0"}] }`.
+
+Monorepo mode respects the catalog enforced by `GitSkillRepository`. Dry runs
+never perform git mutations but still validate references.
+
+## Scenario control (`scenarios.*`)
+
+* `scenarios.toggle(scenario_id, enabled, request_id, dry_run=false)` writes
+  `scenarios/{id}/enabled` in KV and caches the result.
+* `scenarios.bind.set(scenario_id, key, value, request_id, dry_run=false)` stores
+  bindings under `scenarios/{id}/bindings/{key}`. Unknown scenarios return
+  `{ "status": "error", "code": "not_found" }` without raising.
+
+## Resource requests (`resources.*`)
+
+* `resources.request(name, scope, request_id, dry_run=false)` creates a ticket at
+  `resources/requests/{request_id}` with payload `{skill_id, name, scope, status}`.
+* `resources.status(ticket_id)` retrieves ticket state (`pending`, `approved`,
+  `denied`) or `{"status": "not_found"}`.
+
+These calls only create control-plane tickets; actual device access is governed
+by host policy.
+
+## Idempotency & dry runs
+
+All mutating methods accept `request_id` and `dry_run` (default `false`). The
+SDK stores successful responses under `requests/{namespace}/{skill|global}/{request_id}`
+so repeated calls reuse the cached result. `dry_run=true` performs the same
+validation paths without writing state or git changes.
+
+## Error model
+
+* `SdkRuntimeNotInitialized` – runtime context missing.
+* `CapabilityError` – capability token missing or host policy rejects the action.
+* `QuotaExceeded` – KV/FS/NET quota guards deny an operation.
+* `ConflictError` – reserved for idempotency conflicts.
+
+Errors bubble up with structured messages so LLM skills can react accordingly.
+
+## Security considerations
+
+* Keys are namespaced (`skills/{id}/state`, `scenarios/{id}/...`) with validation
+  to prevent path traversal.
+* Repository actions reuse adapters (`GitSkillRepository`, `GitScenarioRepository`),
+  inheriting catalog allow-lists in monorepo deployments.
+* No raw subprocess or network calls escape the SDK; all effects run through
+  services guarded by capability checks and quotas.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
       - "Decorators": sdk/decorators.md
       - "Context": sdk/context.md
       - "Adapters": sdk/adapters.md
+      - "Control Plane": sdk_control_plane.md
   - "Навыки": skills.md
   - "Сценарии": scenarios.md
   - "DevPortal": devportal.md

--- a/src/adaos/sdk/_cap.py
+++ b/src/adaos/sdk/_cap.py
@@ -1,0 +1,58 @@
+"""Capability guard helpers used by SDK control-plane facades."""
+
+from __future__ import annotations
+
+from ._ctx import require_ctx
+from .errors import CapabilityError
+
+__all__ = ["require_cap"]
+
+
+def _allows(caps_obj, capability: str) -> bool:
+    if hasattr(caps_obj, "allows"):
+        try:
+            return bool(caps_obj.allows(capability))
+        except TypeError:
+            return bool(caps_obj.allows("sdk", capability))
+    if hasattr(caps_obj, "check"):
+        try:
+            return bool(caps_obj.check("sdk", [capability]))
+        except TypeError:
+            try:
+                return bool(caps_obj.check([capability]))
+            except TypeError:
+                return bool(caps_obj.check(capability))
+    if hasattr(caps_obj, "require"):
+        try:
+            caps_obj.require("sdk", capability)
+            return True
+        except TypeError:
+            caps_obj.require(capability)
+            return True
+        except Exception:
+            return False
+    if hasattr(caps_obj, "has"):
+        try:
+            return bool(caps_obj.has("sdk", capability))
+        except TypeError:
+            return bool(caps_obj.has(capability))
+    if hasattr(caps_obj, "__contains__"):
+        return capability in caps_obj
+    return False
+
+
+def require_cap(*capabilities: str):
+    """Ensure all capabilities are granted for the active context."""
+
+    if not capabilities:
+        raise ValueError("require_cap expects at least one capability token")
+
+    ctx = require_ctx("Capability check requires runtime context")
+    caps_obj = getattr(ctx, "caps", None)
+    if caps_obj is None:
+        raise CapabilityError(capabilities[0])
+
+    for capability in capabilities:
+        if not _allows(caps_obj, capability):
+            raise CapabilityError(capability)
+    return ctx

--- a/src/adaos/sdk/_caps.py
+++ b/src/adaos/sdk/_caps.py
@@ -1,69 +1,12 @@
-"""Utilities for capability checks within the SDK facades."""
+"""Backward compatible wrapper around the new capability helper."""
 
 from __future__ import annotations
 
-from typing import Any, Iterable, Optional
-
-from .context import get_current_skill
-from .errors import CapabilityError
+from ._cap import require_cap as require_cap
 
 
-def _subject_candidates() -> Iterable[str]:
-    skill = get_current_skill()
-    if skill and getattr(skill, "name", None):
-        sid = getattr(skill, "name")
-        yield f"skill:{sid}"
-        yield sid
-    yield "sdk"
-    yield "global"
+def require_capability(*caps: str):
+    return require_cap(*caps)
 
 
-def require_capability(ctx: Any, capability: str) -> None:
-    """Ensure the current context grants the capability, or raise."""
-
-    caps = getattr(ctx, "caps", None)
-    if caps is None:
-        raise CapabilityError(capability)
-
-    last_error: Optional[Exception] = None
-    # Prefer explicit allow/has checks; fall back to require semantics.
-    for subject in _subject_candidates():
-        if hasattr(caps, "allows"):
-            try:
-                allowed = caps.allows(capability)  # type: ignore[call-arg]
-            except TypeError:
-                allowed = caps.allows(subject, capability)  # type: ignore[call-arg]
-            if allowed:
-                return
-            last_error = CapabilityError(capability, subject)
-            continue
-
-        if hasattr(caps, "has"):
-            try:
-                has_cap = caps.has(subject, capability)  # type: ignore[call-arg]
-            except TypeError as exc:  # pragma: no cover - defensive
-                last_error = exc
-                continue
-            if has_cap:
-                return
-            last_error = CapabilityError(capability, subject)
-            continue
-
-        if hasattr(caps, "require"):
-            try:
-                caps.require(subject, capability)  # type: ignore[call-arg]
-            except Exception as exc:
-                last_error = exc
-                continue
-            return
-
-        break  # unknown capability interface
-
-    if isinstance(last_error, CapabilityError):
-        raise last_error
-    if last_error is not None:
-        raise CapabilityError(capability) from last_error
-    raise CapabilityError(capability)
-
-
-__all__ = ["require_capability"]
+__all__ = ["require_capability", "require_cap"]

--- a/src/adaos/sdk/_ctx.py
+++ b/src/adaos/sdk/_ctx.py
@@ -1,0 +1,21 @@
+"""Runtime helpers for accessing the AgentContext lazily."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from adaos.services.agent_context import get_ctx
+
+from .errors import SdkRuntimeNotInitialized
+
+if TYPE_CHECKING:  # pragma: no cover
+    from adaos.services.agent_context import AgentContext
+
+
+def require_ctx(message: str) -> "AgentContext":
+    """Return the active :class:`AgentContext` or raise a friendly SDK error."""
+
+    try:
+        return get_ctx()
+    except RuntimeError as exc:  # context not initialised yet
+        raise SdkRuntimeNotInitialized(message, detail=str(exc)) from exc

--- a/src/adaos/sdk/_idem.py
+++ b/src/adaos/sdk/_idem.py
@@ -1,0 +1,29 @@
+"""Helpers for idempotent SDK operations."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from ._ctx import require_ctx
+from .context import get_current_skill
+
+__all__ = ["load_request", "save_request"]
+
+
+def _request_key(namespace: str, request_id: str) -> str:
+    skill = get_current_skill()
+    skill_id = skill.name if skill else "global"
+    return f"requests/{namespace}/{skill_id}/{request_id}"
+
+
+def load_request(namespace: str, request_id: str) -> Optional[dict]:
+    ctx = require_ctx("Idempotency helpers require runtime context")
+    key = _request_key(namespace, request_id)
+    value = ctx.kv.get(key)
+    return value if isinstance(value, dict) else None
+
+
+def save_request(namespace: str, request_id: str, result: dict) -> None:
+    ctx = require_ctx("Idempotency helpers require runtime context")
+    key = _request_key(namespace, request_id)
+    ctx.kv.set(key, result)

--- a/src/adaos/sdk/_runtime.py
+++ b/src/adaos/sdk/_runtime.py
@@ -1,24 +1,7 @@
-"""Runtime helpers shared by SDK facades."""
+"""Deprecated helpers kept for backward compatibility."""
 
 from __future__ import annotations
 
-from typing import Optional, TYPE_CHECKING
-
-from adaos.services.agent_context import get_ctx
-
-from .errors import SdkRuntimeNotInitialized
-
-if TYPE_CHECKING:  # pragma: no cover - import for type checking only
-    from adaos.services.agent_context import AgentContext
-
-
-def require_ctx(feature: Optional[str] = None) -> "AgentContext":
-    """Return the active :class:`AgentContext` or raise a SDK-friendly error."""
-
-    try:
-        return get_ctx()
-    except RuntimeError as exc:  # context not initialised yet
-        raise SdkRuntimeNotInitialized(feature, str(exc)) from exc
-
+from ._ctx import require_ctx
 
 __all__ = ["require_ctx"]

--- a/src/adaos/sdk/bus.py
+++ b/src/adaos/sdk/bus.py
@@ -4,8 +4,7 @@ import inspect, time
 from types import SimpleNamespace
 from adaos.services.agent_context import get_ctx
 
-
-class BusNotAvailable(RuntimeError): ...
+from .errors import BusNotAvailable
 
 
 def _bus():

--- a/src/adaos/sdk/context.py
+++ b/src/adaos/sdk/context.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 from typing import Optional
 
-from adaos.services.agent_context import get_ctx
 from adaos.services.skill.context import SkillContextService
 from adaos.ports.skill_context import CurrentSkill
+from ._ctx import require_ctx
 
 
 def set_current_skill(name: str) -> bool:
-    return SkillContextService(get_ctx()).set_current_skill(name)
+    ctx = require_ctx("Skill context requires runtime context")
+    return SkillContextService(ctx).set_current_skill(name)
 
 
 def clear_current_skill() -> None:
-    SkillContextService(get_ctx()).clear_current_skill()
+    ctx = require_ctx("Skill context requires runtime context")
+    SkillContextService(ctx).clear_current_skill()
 
 
 def get_current_skill() -> Optional[CurrentSkill]:
-    return SkillContextService(get_ctx()).get_current_skill()
+    ctx = require_ctx("Skill context requires runtime context")
+    return SkillContextService(ctx).get_current_skill()

--- a/src/adaos/sdk/decorators.py
+++ b/src/adaos/sdk/decorators.py
@@ -54,6 +54,8 @@ def tool(
     examples: Optional[list[str]] = None,
     since: Optional[str] = None,
     version: Optional[str] = None,
+    input_schema: Optional[dict] = None,
+    output_schema: Optional[dict] = None,
 ):
     """Маркер инструмента с публичным именем и метаданными."""
 
@@ -71,6 +73,8 @@ def tool(
             "examples": (examples or []),
             "since": since,
             "version": version,
+            "input_schema": input_schema,
+            "output_schema": output_schema,
         }
         return fn
 

--- a/src/adaos/sdk/errors.py
+++ b/src/adaos/sdk/errors.py
@@ -1,48 +1,52 @@
+"""Common SDK-side exceptions shared by control-plane facades."""
+
 from __future__ import annotations
 
 from typing import Optional
 
-
-class SdkError(RuntimeError):
-    """Base class for all SDK-level runtime errors."""
-
-
-class SdkRuntimeNotInitialized(SdkError):
-    """Raised when an SDK facade is invoked without an active AgentContext."""
-
-    def __init__(self, feature: Optional[str] = None, detail: Optional[str] = None) -> None:
-        self.feature = feature
-        self.detail = detail
-        message = "AdaOS SDK runtime is not initialized"
-        if feature:
-            message = f"{feature} requires AdaOS runtime context"
-        if detail:
-            message = f"{message}: {detail}"
-        super().__init__(message)
-
-
-class CapabilityError(SdkError):
-    """Raised when a capability required by the SDK facade is missing."""
-
-    def __init__(self, capability: str, subject: Optional[str] = None) -> None:
-        self.capability = capability
-        self.subject = subject
-        if subject:
-            message = f"Capability '{capability}' is not granted for subject '{subject}'"
-        else:
-            message = f"Capability '{capability}' is not granted"
-        super().__init__(message)
-
-
-class BusNotAvailable(SdkError):
-    """Raised when event bus operations are requested but bus is unavailable."""
-
-    pass
-
-
 __all__ = [
-    "SdkError",
     "SdkRuntimeNotInitialized",
     "CapabilityError",
+    "QuotaExceeded",
+    "ConflictError",
     "BusNotAvailable",
 ]
+
+
+class SdkRuntimeNotInitialized(RuntimeError):
+    """Raised when an SDK facade is invoked without an active AgentContext."""
+
+    def __init__(self, message: str = "AdaOS SDK runtime is not initialized", *, detail: Optional[str] = None) -> None:
+        self.detail = detail
+        super().__init__(message if detail is None else f"{message}: {detail}")
+
+
+class CapabilityError(PermissionError):
+    """Raised when the current context lacks a required capability token."""
+
+    def __init__(self, capability: str, *, message: str | None = None) -> None:
+        self.capability = capability
+        super().__init__(message or f"missing capability: {capability}")
+
+
+class QuotaExceeded(RuntimeError):
+    """Raised when a quota guard rejects an operation (KV / FS / NET)."""
+
+    def __init__(self, resource: str | None = None, *, message: str | None = None) -> None:
+        self.resource = resource
+        text = message or (f"quota exceeded: {resource}" if resource else "quota exceeded")
+        super().__init__(text)
+
+
+class ConflictError(RuntimeError):
+    """Raised when an idempotent operation detects a conflicting request id."""
+
+    def __init__(self, request_id: str, *, message: str | None = None) -> None:
+        self.request_id = request_id
+        super().__init__(message or f"conflicting request_id: {request_id}")
+
+
+class BusNotAvailable(RuntimeError):
+    """Raised when an event bus operation is requested without a configured bus."""
+
+    pass

--- a/src/adaos/sdk/exporter.py
+++ b/src/adaos/sdk/exporter.py
@@ -123,6 +123,10 @@ def export(level: str = "std") -> dict:
                 },
                 "examples": tm.get("examples", []),
             }
+            if tm.get("input_schema"):
+                item["input_schema"] = tm["input_schema"]
+            if tm.get("output_schema"):
+                item["output_schema"] = tm["output_schema"]
             if level in ("std", "rich"):
                 sig = inspect.signature(fn)
                 args = []

--- a/src/adaos/sdk/manage.py
+++ b/src/adaos/sdk/manage.py
@@ -2,27 +2,682 @@
 
 from __future__ import annotations
 
-from ._caps import require_capability
-from ._runtime import require_ctx
-from .validation.skill import ValidationReport, validate_self as _validate_self
+from typing import Any, Dict, Optional
 
-__all__ = ["self_validate", "scenario_toggle"]
+from adaos.domain import SkillMeta
+from adaos.services.resources.requests import ResourceRequestService
+from adaos.services.scenario.control import ScenarioControlService
+from adaos.services.skill.lifecycle import SkillLifecycleService
+from adaos.services.skill.state import SkillStateService, _validate_key as _validate_state_key
+from adaos.services.skill.update import SkillUpdateService
+from adaos.services.skill.validation import SkillValidationService
+
+from ._cap import require_cap
+from ._idem import load_request, save_request
+from .context import get_current_skill
+from .decorators import tool
+from .errors import CapabilityError, QuotaExceeded
 
 
-def self_validate(strict: bool = False, probe_tools: bool = False) -> ValidationReport:
-    return _validate_self(strict=strict, probe_tools=probe_tools)
+_JSON_ANY = {"type": ["object", "array", "string", "number", "boolean", "null"]}
 
 
-def scenario_toggle(scenario_id: str, enabled: bool) -> None:
-    ctx = require_ctx("sdk.manage.scenario_toggle")
-    require_capability(ctx, "manage.scenarios.toggle")
+def _issue_to_dict(issue: Any) -> Dict[str, Any]:
+    return {
+        "level": getattr(issue, "level", "error"),
+        "code": getattr(issue, "code", "unknown"),
+        "message": getattr(issue, "message", ""),
+        "where": getattr(issue, "where", None),
+    }
 
-    svc = getattr(ctx, "scenario_control", None) or getattr(ctx, "scenario_manager", None)
-    if svc is None:
-        raise NotImplementedError("Scenario toggle service is not wired into the current runtime")
 
-    toggle = getattr(svc, "toggle", None) or getattr(svc, "set_enabled", None)
-    if toggle is None:
-        raise NotImplementedError("Scenario service does not expose toggle() or set_enabled()")
+def _meta_to_dict(meta: SkillMeta | None) -> Dict[str, Any]:
+    if meta is None:
+        return {"id": None, "name": None, "version": None}
+    return {"id": meta.id.value, "name": meta.name, "version": getattr(meta, "version", None)}
 
-    toggle(scenario_id, enabled)
+
+def _current_skill_id() -> Optional[str]:
+    skill = get_current_skill()
+    return skill.name if skill else None
+
+
+def _wrap_quota(fn):
+    try:
+        return fn()
+    except Exception as exc:  # pragma: no cover - defensive guard
+        text = str(exc).lower()
+        if "quota" in text or getattr(exc, "quota_exceeded", False):
+            raise QuotaExceeded(message=str(exc)) from exc
+        raise
+
+
+@tool(
+    "manage.self.validate",
+    summary="Validate the current skill against schema and runtime exports",
+    stability="stable",
+    examples=["manage.self.validate(strict=true)"],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "strict": {"type": "boolean", "default": False},
+            "probe_tools": {"type": "boolean", "default": False},
+        },
+        "required": [],
+        "additionalProperties": False,
+    },
+    output_schema={
+        "type": "object",
+        "properties": {
+            "ok": {"type": "boolean"},
+            "issues": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "level": {"type": "string"},
+                        "code": {"type": "string"},
+                        "message": {"type": "string"},
+                        "where": {"type": ["string", "null"]},
+                    },
+                    "required": ["level", "code", "message"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+        "required": ["ok", "issues"],
+        "additionalProperties": False,
+    },
+)
+def self_validate(strict: bool = False, probe_tools: bool = False) -> dict:
+    ctx = require_cap("manage.self.validate")
+    skill_id = _current_skill_id()
+    report = SkillValidationService(ctx).validate(skill_id, strict=strict, probe_tools=probe_tools)
+    return {"ok": bool(report.ok), "issues": [_issue_to_dict(issue) for issue in report.issues]}
+
+
+@tool(
+    "manage.self.state.get",
+    summary="Get private per-skill state from KV",
+    stability="stable",
+    examples=["manage.self.state.get('last_run')"],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "key": {"type": "string"},
+            "default": _JSON_ANY,
+        },
+        "required": ["key"],
+        "additionalProperties": False,
+    },
+    output_schema={
+        "type": "object",
+        "properties": {
+            "status": {"type": "string"},
+            "key": {"type": "string"},
+            "value": _JSON_ANY,
+            "found": {"type": "boolean"},
+        },
+        "required": ["status", "key", "value", "found"],
+        "additionalProperties": False,
+    },
+)
+def self_state_get(key: str, default: object | None = None) -> dict:
+    ctx = require_cap("manage.self.state")
+    skill_id = _current_skill_id()
+    service = SkillStateService(ctx)
+    value, found = service.get(skill_id, key, default)
+    return {"status": "ok", "key": key, "value": value, "found": found}
+
+
+@tool(
+    "manage.self.state.put",
+    summary="Set private per-skill state in KV",
+    stability="stable",
+    examples=["manage.self.state.put('last_run', {'ts': 1690000000}, request_id='abc')"],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "key": {"type": "string"},
+            "value": _JSON_ANY,
+            "request_id": {"type": "string"},
+            "dry_run": {"type": "boolean", "default": False},
+        },
+        "required": ["key", "value", "request_id"],
+        "additionalProperties": False,
+    },
+    output_schema={
+        "type": "object",
+        "properties": {
+            "status": {"type": "string"},
+            "key": {"type": "string"},
+            "value": _JSON_ANY,
+            "stored": {"type": "boolean"},
+            "dry_run": {"type": "boolean"},
+            "request_id": {"type": "string"},
+            "previous": _JSON_ANY,
+            "previous_exists": {"type": "boolean"},
+        },
+        "required": ["status", "key", "value", "stored", "dry_run", "request_id", "previous", "previous_exists"],
+        "additionalProperties": False,
+    },
+)
+def self_state_put(key: str, value: object, request_id: str, dry_run: bool = False) -> dict:
+    if not request_id:
+        raise ValueError("request_id must be provided")
+
+    ctx = require_cap("manage.self.state")
+    skill_id = _current_skill_id()
+    service = SkillStateService(ctx)
+
+    if not dry_run:
+        cached = load_request("manage.self.state.put", request_id)
+        if cached is not None:
+            return cached
+
+    preview_value, preview_exists = service.get(skill_id, key)
+
+    result = {
+        "status": "ok",
+        "key": key,
+        "value": value,
+        "stored": False,
+        "dry_run": dry_run,
+        "request_id": request_id,
+        "previous": preview_value,
+        "previous_exists": preview_exists,
+    }
+
+    if dry_run:
+        service.request_key(skill_id, request_id)  # validate request namespace
+        return result
+
+    _wrap_quota(lambda: service.set(skill_id, key, value))
+    result["stored"] = True
+    _wrap_quota(lambda: save_request("manage.self.state.put", request_id, result))
+    alias_key = service.request_key(skill_id, request_id)
+    _wrap_quota(lambda: ctx.kv.set(alias_key, result))
+    return result
+
+
+@tool(
+    "manage.self.update.request",
+    summary="Request pulling latest version of the current skill",
+    stability="beta",
+    examples=["manage.self.update.request(request_id='abc', dry_run=true)"],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "request_id": {"type": "string"},
+            "dry_run": {"type": "boolean", "default": False},
+        },
+        "required": ["request_id"],
+        "additionalProperties": False,
+    },
+    output_schema={
+        "type": "object",
+        "properties": {
+            "status": {"type": "string"},
+            "updated": {"type": "boolean"},
+            "version": {"type": ["string", "null"]},
+            "dry_run": {"type": "boolean"},
+            "request_id": {"type": "string"},
+            "message": {"type": ["string", "null"]},
+        },
+        "required": ["status", "updated", "dry_run", "request_id"],
+        "additionalProperties": False,
+    },
+)
+def self_update_request(request_id: str, dry_run: bool = False) -> dict:
+    if not request_id:
+        raise ValueError("request_id must be provided")
+
+    ctx = require_cap("manage.self.update")
+    skill_id = _current_skill_id()
+    if not skill_id:
+        return {"status": "error", "code": "skill_not_selected", "updated": False, "dry_run": dry_run, "request_id": request_id}
+
+    if not dry_run:
+        cached = load_request("manage.self.update.request", request_id)
+        if cached is not None:
+            return cached
+
+    service = SkillUpdateService(ctx)
+    try:
+        update_result = service.request_update(skill_id, dry_run=dry_run)
+    except PermissionError as exc:
+        raise CapabilityError("manage.self.update") from exc
+    except FileNotFoundError as exc:
+        return {
+            "status": "error",
+            "code": "not_found",
+            "message": str(exc),
+            "updated": False,
+            "dry_run": dry_run,
+            "request_id": request_id,
+        }
+
+    result = {
+        "status": "ok",
+        "updated": bool(update_result.updated),
+        "version": update_result.version,
+        "dry_run": dry_run,
+        "request_id": request_id,
+    }
+
+    if dry_run:
+        return result
+
+    _wrap_quota(lambda: save_request("manage.self.update.request", request_id, result))
+    return result
+
+
+@tool(
+    "skills.install",
+    summary="Install a skill (monorepo name or git url)",
+    stability="beta",
+    examples=["skills.install('weather_skill', request_id='abc')", "skills.install('https://example/git/foo.git', request_id='abc')"],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "ref": {"type": "string"},
+            "branch": {"type": ["string", "null"]},
+            "dest_name": {"type": ["string", "null"]},
+            "request_id": {"type": "string"},
+            "dry_run": {"type": "boolean", "default": False},
+        },
+        "required": ["ref", "request_id"],
+        "additionalProperties": False,
+    },
+    output_schema={
+        "type": "object",
+        "properties": {
+            "status": {"type": "string"},
+            "action": {"type": "string"},
+            "skill": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": ["string", "null"]},
+                    "name": {"type": ["string", "null"]},
+                    "version": {"type": ["string", "null"]},
+                },
+                "required": ["id", "name", "version"],
+                "additionalProperties": False,
+            },
+            "dry_run": {"type": "boolean"},
+            "request_id": {"type": "string"},
+        },
+        "required": ["status", "action", "skill", "dry_run", "request_id"],
+        "additionalProperties": False,
+    },
+)
+def skills_install(
+    ref: str,
+    *,
+    branch: str | None = None,
+    dest_name: str | None = None,
+    request_id: str,
+    dry_run: bool = False,
+) -> dict:
+    if not request_id:
+        raise ValueError("request_id must be provided")
+
+    ctx = require_cap("manage.skills.install")
+    service = SkillLifecycleService(ctx)
+    target_id = dest_name or ref
+    repo = ctx.skills_repo
+    repo.ensure()
+    existing = repo.get(target_id)
+
+    if not dry_run:
+        cached = load_request("manage.skills.install", request_id)
+        if cached is not None:
+            return cached
+
+    if dry_run:
+        action = "noop" if existing else "install"
+        if existing is None:
+            meta_dict = {"id": target_id, "name": target_id, "version": None}
+        else:
+            meta_dict = _meta_to_dict(existing)
+        result = {"status": "ok", "action": action, "skill": meta_dict, "dry_run": True, "request_id": request_id}
+        return result
+
+    meta = _wrap_quota(lambda: service.install(ref, branch=branch, dest_name=dest_name))
+    result = {
+        "status": "ok",
+        "action": "install",
+        "skill": _meta_to_dict(meta),
+        "dry_run": False,
+        "request_id": request_id,
+    }
+    _wrap_quota(lambda: save_request("manage.skills.install", request_id, result))
+    return result
+
+
+@tool(
+    "skills.uninstall",
+    summary="Uninstall a skill by id",
+    stability="beta",
+    examples=["skills.uninstall('weather_skill', request_id='xyz')"],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "skill_id": {"type": "string"},
+            "request_id": {"type": "string"},
+            "dry_run": {"type": "boolean", "default": False},
+        },
+        "required": ["skill_id", "request_id"],
+        "additionalProperties": False,
+    },
+    output_schema={
+        "type": "object",
+        "properties": {
+            "status": {"type": "string"},
+            "action": {"type": "string"},
+            "skill_id": {"type": "string"},
+            "dry_run": {"type": "boolean"},
+            "request_id": {"type": "string"},
+        },
+        "required": ["status", "action", "skill_id", "dry_run", "request_id"],
+        "additionalProperties": False,
+    },
+)
+def skills_uninstall(skill_id: str, request_id: str, dry_run: bool = False) -> dict:
+    if not request_id:
+        raise ValueError("request_id must be provided")
+
+    ctx = require_cap("manage.skills.uninstall")
+    service = SkillLifecycleService(ctx)
+
+    if not dry_run:
+        cached = load_request("manage.skills.uninstall", request_id)
+        if cached is not None:
+            return cached
+
+    repo = ctx.skills_repo
+    repo.ensure()
+    existing = repo.get(skill_id)
+
+    if dry_run:
+        action = "removed" if existing else "noop"
+        return {
+            "status": "ok",
+            "action": action,
+            "skill_id": skill_id,
+            "dry_run": True,
+            "request_id": request_id,
+        }
+
+    removed = _wrap_quota(lambda: service.uninstall(skill_id))
+    result = {
+        "status": "ok",
+        "action": "removed" if removed else "noop",
+        "skill_id": skill_id,
+        "dry_run": False,
+        "request_id": request_id,
+    }
+    _wrap_quota(lambda: save_request("manage.skills.uninstall", request_id, result))
+    return result
+
+
+@tool(
+    "skills.list",
+    summary="List installed skills",
+    stability="stable",
+    examples=["skills.list()"],
+    input_schema={"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+    output_schema={
+        "type": "object",
+        "properties": {
+            "skills": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": ["string", "null"]},
+                        "name": {"type": ["string", "null"]},
+                        "version": {"type": ["string", "null"]},
+                    },
+                    "required": ["id", "name", "version"],
+                    "additionalProperties": False,
+                },
+            }
+        },
+        "required": ["skills"],
+        "additionalProperties": False,
+    },
+)
+def skills_list() -> dict:
+    ctx = require_cap("manage.skills.list")
+    service = SkillLifecycleService(ctx)
+    metas = service.list_installed()
+    return {"skills": [_meta_to_dict(meta) for meta in metas]}
+
+
+@tool(
+    "scenarios.toggle",
+    summary="Enable or disable a scenario",
+    stability="stable",
+    examples=["scenarios.toggle('morning', enabled=true, request_id='req1')"],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "scenario_id": {"type": "string"},
+            "enabled": {"type": "boolean"},
+            "request_id": {"type": "string"},
+            "dry_run": {"type": "boolean", "default": False},
+        },
+        "required": ["scenario_id", "enabled", "request_id"],
+        "additionalProperties": False,
+    },
+    output_schema={
+        "type": "object",
+        "properties": {
+            "status": {"type": "string"},
+            "scenario_id": {"type": "string"},
+            "enabled": {"type": "boolean"},
+            "dry_run": {"type": "boolean"},
+            "request_id": {"type": "string"},
+        },
+        "required": ["status", "scenario_id", "enabled", "dry_run", "request_id"],
+        "additionalProperties": False,
+    },
+)
+def scenarios_toggle(scenario_id: str, enabled: bool, request_id: str, dry_run: bool = False) -> dict:
+    if not request_id:
+        raise ValueError("request_id must be provided")
+
+    ctx = require_cap("manage.scenarios.toggle")
+
+    if not dry_run:
+        cached = load_request("manage.scenarios.toggle", request_id)
+        if cached is not None:
+            return cached
+
+    service = ScenarioControlService(ctx)
+    if not dry_run:
+        _wrap_quota(lambda: service.set_enabled(scenario_id, enabled))
+    result = {
+        "status": "ok",
+        "scenario_id": scenario_id,
+        "enabled": bool(enabled),
+        "dry_run": dry_run,
+        "request_id": request_id,
+    }
+    if not dry_run:
+        _wrap_quota(lambda: save_request("manage.scenarios.toggle", request_id, result))
+    return result
+
+
+@tool(
+    "scenarios.bind.set",
+    summary="Set a binding (param/device) for a scenario",
+    stability="beta",
+    examples=["scenarios.bind.set('alarm', key='mic', value='default', request_id='a1')"],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "scenario_id": {"type": "string"},
+            "key": {"type": "string"},
+            "value": {"type": "string"},
+            "request_id": {"type": "string"},
+            "dry_run": {"type": "boolean", "default": False},
+        },
+        "required": ["scenario_id", "key", "value", "request_id"],
+        "additionalProperties": False,
+    },
+    output_schema={
+        "type": "object",
+        "properties": {
+            "status": {"type": "string"},
+            "scenario_id": {"type": "string"},
+            "key": {"type": "string"},
+            "value": {"type": "string"},
+            "dry_run": {"type": "boolean"},
+            "request_id": {"type": "string"},
+            "code": {"type": ["string", "null"]},
+        },
+        "required": ["status", "scenario_id", "key", "value", "dry_run", "request_id"],
+        "additionalProperties": False,
+    },
+)
+def scenarios_bind_set(scenario_id: str, key: str, value: str, request_id: str, dry_run: bool = False) -> dict:
+    if not request_id:
+        raise ValueError("request_id must be provided")
+
+    ctx = require_cap("manage.scenarios.bind")
+    _validate_state_key(key)
+
+    if not dry_run:
+        cached = load_request("manage.scenarios.bind.set", request_id)
+        if cached is not None:
+            return cached
+
+    service = ScenarioControlService(ctx)
+
+    repo = ctx.scenarios_repo
+    repo.ensure()
+    exists = repo.get(scenario_id) is not None
+    if not exists:
+        result = {
+            "status": "error",
+            "code": "not_found",
+            "scenario_id": scenario_id,
+            "key": key,
+            "value": value,
+            "dry_run": dry_run,
+            "request_id": request_id,
+        }
+        if not dry_run:
+            _wrap_quota(lambda: save_request("manage.scenarios.bind.set", request_id, result))
+        return result
+
+    if not dry_run:
+        _wrap_quota(lambda: service.set_binding(scenario_id, key, value))
+
+    result = {
+        "status": "ok",
+        "scenario_id": scenario_id,
+        "key": key,
+        "value": value,
+        "dry_run": dry_run,
+        "request_id": request_id,
+        "code": None,
+    }
+    if not dry_run:
+        _wrap_quota(lambda: save_request("manage.scenarios.bind.set", request_id, result))
+    return result
+
+
+@tool(
+    "resources.request",
+    summary="Request access to a resource",
+    stability="alpha",
+    examples=["resources.request('microphone', scope='read', request_id='r1')"],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "scope": {"type": "string"},
+            "request_id": {"type": "string"},
+            "dry_run": {"type": "boolean", "default": False},
+        },
+        "required": ["name", "scope", "request_id"],
+        "additionalProperties": False,
+    },
+    output_schema={
+        "type": "object",
+        "properties": {
+            "status": {"type": "string"},
+            "ticket_id": {"type": "string"},
+            "dry_run": {"type": "boolean"},
+            "details": {"type": "object"},
+        },
+        "required": ["status", "ticket_id", "dry_run", "details"],
+        "additionalProperties": False,
+    },
+)
+def resources_request(name: str, scope: str, request_id: str, dry_run: bool = False) -> dict:
+    if not request_id:
+        raise ValueError("request_id must be provided")
+
+    ctx = require_cap("manage.resources.request")
+    skill_id = _current_skill_id()
+    payload = {"skill_id": skill_id, "name": name, "scope": scope, "status": "pending"}
+
+    if not dry_run:
+        cached = load_request("manage.resources.request", request_id)
+        if cached is not None:
+            return cached
+
+    if dry_run:
+        return {
+            "status": "pending",
+            "ticket_id": request_id,
+            "dry_run": True,
+            "details": payload,
+        }
+
+    service = ResourceRequestService(ctx)
+    ticket = _wrap_quota(lambda: service.create_ticket(request_id, payload))
+    result = {
+        "status": ticket.status,
+        "ticket_id": ticket.ticket_id,
+        "dry_run": False,
+        "details": ticket.payload,
+    }
+    _wrap_quota(lambda: save_request("manage.resources.request", request_id, result))
+    return result
+
+
+@tool(
+    "resources.status",
+    summary="Check ticket status",
+    stability="alpha",
+    examples=["resources.status('r1')"],
+    input_schema={
+        "type": "object",
+        "properties": {
+            "ticket_id": {"type": "string"},
+        },
+        "required": ["ticket_id"],
+        "additionalProperties": False,
+    },
+    output_schema={
+        "type": "object",
+        "properties": {
+            "status": {"type": "string"},
+            "ticket": {"type": ["object", "null"]},
+        },
+        "required": ["status", "ticket"],
+        "additionalProperties": False,
+    },
+)
+def resources_status(ticket_id: str) -> dict:
+    ctx = require_cap("manage.resources.status")
+    service = ResourceRequestService(ctx)
+    ticket = service.get_ticket(ticket_id)
+    if ticket is None:
+        return {"status": "not_found", "ticket": None}
+    return {"status": ticket.status, "ticket": ticket.payload}

--- a/src/adaos/services/resources/__init__.py
+++ b/src/adaos/services/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Resource management services."""

--- a/src/adaos/services/resources/requests.py
+++ b/src/adaos/services/resources/requests.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from adaos.services.agent_context import AgentContext
+
+
+@dataclass(slots=True)
+class ResourceTicket:
+    ticket_id: str
+    status: str
+    payload: dict
+
+
+@dataclass(slots=True)
+class ResourceRequestService:
+    ctx: AgentContext
+
+    def create_ticket(self, ticket_id: str, payload: dict) -> ResourceTicket:
+        key = f"resources/requests/{ticket_id}"
+        existing = self.ctx.kv.get(key)
+        if isinstance(existing, dict):
+            return ResourceTicket(ticket_id=ticket_id, status=str(existing.get("status", "pending")), payload=existing)
+        payload = {**payload, "status": payload.get("status", "pending"), "ticket_id": ticket_id}
+        self.ctx.kv.set(key, payload)
+        return ResourceTicket(ticket_id=ticket_id, status=str(payload.get("status", "pending")), payload=payload)
+
+    def get_ticket(self, ticket_id: str) -> Optional[ResourceTicket]:
+        key = f"resources/requests/{ticket_id}"
+        value = self.ctx.kv.get(key)
+        if not isinstance(value, dict):
+            return None
+        status = str(value.get("status", "pending"))
+        return ResourceTicket(ticket_id=ticket_id, status=status, payload=value)

--- a/src/adaos/services/scenario/control.py
+++ b/src/adaos/services/scenario/control.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from adaos.services.agent_context import AgentContext
+
+from ..skill.state import _validate_key as _validate_binding_key  # reuse validation rules
+
+
+@dataclass(slots=True)
+class ScenarioControlService:
+    ctx: AgentContext
+
+    def set_enabled(self, scenario_id: str, enabled: bool) -> None:
+        key = f"scenarios/{scenario_id}/enabled"
+        self.ctx.kv.set(key, bool(enabled))
+
+    def set_binding(self, scenario_id: str, key: str, value: str) -> bool:
+        repo = getattr(self.ctx, "scenarios_repo", None)
+        if repo is not None:
+            try:
+                repo.ensure()
+            except Exception:
+                pass
+            if repo.get(scenario_id) is None:
+                return False
+        storage_key = f"scenarios/{scenario_id}/bindings/{_validate_binding_key(key)}"
+        self.ctx.kv.set(storage_key, value)
+        return True

--- a/src/adaos/services/skill/lifecycle.py
+++ b/src/adaos/services/skill/lifecycle.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from adaos.domain import SkillMeta
+from adaos.services.agent_context import AgentContext
+
+
+@dataclass(slots=True)
+class SkillLifecycleService:
+    ctx: AgentContext
+
+    def list_installed(self) -> list[SkillMeta]:
+        repo = self.ctx.skills_repo
+        repo.ensure()
+        return repo.list()
+
+    def install(self, ref: str, *, branch: Optional[str] = None, dest_name: Optional[str] = None) -> SkillMeta:
+        repo = self.ctx.skills_repo
+        return repo.install(ref, branch=branch, dest_name=dest_name)
+
+    def uninstall(self, skill_id: str) -> bool:
+        repo = self.ctx.skills_repo
+        try:
+            repo.uninstall(skill_id)
+            return True
+        except FileNotFoundError:
+            return False

--- a/src/adaos/services/skill/state.py
+++ b/src/adaos/services/skill/state.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Tuple
+
+from adaos.services.agent_context import AgentContext
+
+_KEY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*$")
+
+
+def _validate_key(key: str) -> str:
+    if not key:
+        raise ValueError("state key must be non-empty")
+    if key.startswith("/"):
+        raise ValueError("state key must be relative")
+    if ".." in key.split("/"):
+        raise ValueError("state key must not contain path traversal")
+    if not _KEY_PATTERN.fullmatch(key):
+        raise ValueError("state key contains unsupported characters")
+    return key
+
+
+@dataclass(slots=True)
+class SkillStateService:
+    ctx: AgentContext
+
+    def _state_prefix(self, skill_id: str | None) -> str:
+        if skill_id:
+            return f"skills/{skill_id}/state"
+        return "global/state"
+
+    def _request_prefix(self, skill_id: str | None) -> str:
+        if skill_id:
+            return f"skills/{skill_id}/requests"
+        return "global/requests"
+
+    def get(self, skill_id: str | None, key: str, default: Any = None) -> Tuple[Any, bool]:
+        key = _validate_key(key)
+        storage_key = f"{self._state_prefix(skill_id)}/{key}"
+        sentinel = object()
+        value = self.ctx.kv.get(storage_key, sentinel)
+        if value is sentinel:
+            return default, False
+        return value, True
+
+    def set(self, skill_id: str | None, key: str, value: Any) -> str:
+        key = _validate_key(key)
+        storage_key = f"{self._state_prefix(skill_id)}/{key}"
+        self.ctx.kv.set(storage_key, value)
+        return storage_key
+
+    def request_key(self, skill_id: str | None, request_id: str) -> str:
+        if not request_id:
+            raise ValueError("request_id must be non-empty")
+        if ".." in request_id.split("/"):
+            raise ValueError("request_id must not contain path traversal")
+        return f"{self._request_prefix(skill_id)}/{request_id}"

--- a/src/adaos/services/skill/update.py
+++ b/src/adaos/services/skill/update.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from adaos.services.agent_context import AgentContext
+
+
+@dataclass(slots=True)
+class SkillUpdateResult:
+    updated: bool
+    version: Optional[str]
+
+
+@dataclass(slots=True)
+class SkillUpdateService:
+    ctx: AgentContext
+
+    def request_update(self, skill_id: str, *, dry_run: bool = False) -> SkillUpdateResult:
+        repo = self.ctx.skills_repo
+        meta = repo.get(skill_id)
+        if meta is None:
+            raise FileNotFoundError(f"skill '{skill_id}' is not installed")
+
+        root = Path(self.ctx.paths.skills_dir())
+        skill_path = Path(getattr(meta, "path", root / skill_id))
+        version = getattr(meta, "version", None)
+
+        if dry_run:
+            return SkillUpdateResult(updated=False, version=version)
+
+        fs = getattr(self.ctx, "fs", None)
+        if fs and hasattr(fs, "require_write"):
+            try:
+                fs.require_write(str(skill_path))
+            except Exception as exc:
+                raise PermissionError("fs.readonly") from exc
+        settings = getattr(self.ctx, "settings", None)
+        git = getattr(self.ctx, "git", None)
+        if git is None:
+            raise RuntimeError("Git client is not configured")
+
+        if settings and getattr(settings, "skills_monorepo_url", None):
+            if fs and hasattr(fs, "require_write"):
+                try:
+                    fs.require_write(str(root))
+                except Exception as exc:
+                    raise PermissionError("fs.readonly") from exc
+            git.sparse_add(str(root), skill_id)
+            git.pull(str(root))
+        else:
+            git.pull(str(skill_path))
+
+        refreshed = repo.get(skill_id) or meta
+        return SkillUpdateResult(updated=True, version=getattr(refreshed, "version", version))

--- a/tests/sdk/test_manage_resources.py
+++ b/tests/sdk/test_manage_resources.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from adaos.sdk.errors import CapabilityError
+from adaos.sdk.manage import resources_request, resources_status
+from adaos.services.agent_context import get_ctx
+
+
+class AllowCaps:
+    def __init__(self, allowed: set[str]):
+        self._allowed = allowed
+
+    def allows(self, capability: str) -> bool:
+        return capability in self._allowed
+
+
+def test_resources_request_and_status():
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.resources.request", "manage.resources.status"})
+
+    res = resources_request("microphone", scope="read", request_id="req-r1")
+    assert res["status"] == "pending"
+    assert res["dry_run"] is False
+
+    status = resources_status("req-r1")
+    assert status["status"] == "pending"
+    assert status["ticket"]["ticket_id"] == "req-r1"
+
+    # repeated request id returns cached result
+    assert resources_request("microphone", scope="read", request_id="req-r1") == res
+
+
+def test_resources_request_dry_run():
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.resources.request"})
+
+    preview = resources_request("camera", scope="write", request_id="req-preview", dry_run=True)
+    assert preview["dry_run"] is True
+    assert ctx.kv.get("resources/requests/req-preview") is None
+
+
+def test_resources_status_not_found():
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.resources.status"})
+    assert resources_status("missing") == {"status": "not_found", "ticket": None}
+
+
+def test_resources_request_missing_capability():
+    ctx = get_ctx()
+    ctx.caps = AllowCaps(set())
+    with pytest.raises(CapabilityError):
+        resources_request("microphone", scope="read", request_id="req-no-cap")

--- a/tests/sdk/test_manage_scenarios.py
+++ b/tests/sdk/test_manage_scenarios.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from adaos.sdk.errors import CapabilityError
+from adaos.sdk.manage import scenarios_bind_set, scenarios_toggle
+from adaos.services.agent_context import get_ctx
+
+
+class AllowCaps:
+    def __init__(self, allowed: set[str]):
+        self._allowed = allowed
+
+    def allows(self, capability: str) -> bool:
+        return capability in self._allowed
+
+
+@dataclass
+class FakeScenarioRepo:
+    existing: set[str]
+
+    def ensure(self) -> None:
+        pass
+
+    def get(self, scenario_id: str):
+        return scenario_id if scenario_id in self.existing else None
+
+
+@pytest.fixture
+def scenario_repo():
+    ctx = get_ctx()
+    repo = FakeScenarioRepo(existing={"morning"})
+    object.__setattr__(ctx, "_scenarios_repo", repo)
+    return repo
+
+
+def test_scenarios_toggle_idempotent(scenario_repo):
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.scenarios.toggle"})
+
+    res = scenarios_toggle("morning", True, request_id="req-toggle")
+    assert res == {"status": "ok", "scenario_id": "morning", "enabled": True, "dry_run": False, "request_id": "req-toggle"}
+    assert ctx.kv.get("scenarios/morning/enabled") is True
+
+    # repeat with same request id returns cached result
+    assert scenarios_toggle("morning", False, request_id="req-toggle") == res
+
+
+def test_scenarios_toggle_dry_run(scenario_repo):
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.scenarios.toggle"})
+
+    preview = scenarios_toggle("morning", False, request_id="req-dry", dry_run=True)
+    assert preview["dry_run"] is True
+    assert ctx.kv.get("scenarios/morning/enabled") is None
+
+
+def test_scenarios_bind_set_not_found(scenario_repo):
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.scenarios.bind"})
+    scenario_repo.existing.clear()
+
+    res = scenarios_bind_set("missing", key="mic", value="default", request_id="req-bind")
+    assert res["status"] == "error"
+    assert res["code"] == "not_found"
+
+
+def test_scenarios_bind_set_ok(scenario_repo):
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.scenarios.bind"})
+
+    res = scenarios_bind_set("morning", key="mic", value="default", request_id="req-bind-ok")
+    assert res["status"] == "ok"
+    assert ctx.kv.get("scenarios/morning/bindings/mic") == "default"
+
+
+def test_scenarios_toggle_missing_capability(scenario_repo):
+    ctx = get_ctx()
+    ctx.caps = AllowCaps(set())
+    with pytest.raises(CapabilityError):
+        scenarios_toggle("morning", True, request_id="req-no-cap")

--- a/tests/sdk/test_manage_self.py
+++ b/tests/sdk/test_manage_self.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from adaos.sdk.errors import CapabilityError, SdkRuntimeNotInitialized
+from adaos.sdk.manage import self_state_get, self_state_put, self_update_request, self_validate
+from adaos.services.agent_context import clear_ctx, get_ctx, set_ctx
+from adaos.services.skill.update import SkillUpdateResult, SkillUpdateService
+from adaos.services.skill.validation import Issue, SkillValidationService, ValidationReport
+
+
+class AllowCaps:
+    def __init__(self, allowed: set[str]):
+        self._allowed = allowed
+
+    def allows(self, capability: str) -> bool:
+        return capability in self._allowed
+
+
+def _ensure_skill(ctx, name: str = "demo") -> None:
+    skill_dir = Path(ctx.paths.skills_dir()) / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    ctx.skill_ctx.set(name, skill_dir)
+
+
+def test_self_validate_ok(monkeypatch):
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.self.validate"})
+    _ensure_skill(ctx, "demo")
+
+    report = ValidationReport(ok=True, issues=[Issue(level="warning", code="warn", message="note", where="skill.yaml")])
+    monkeypatch.setattr(SkillValidationService, "validate", lambda self, skill_id, strict=False, probe_tools=False: report)
+
+    result = self_validate(strict=True, probe_tools=True)
+    assert result["ok"] is True
+    assert result["issues"] == [
+        {"level": "warning", "code": "warn", "message": "note", "where": "skill.yaml"}
+    ]
+
+
+def test_self_validate_missing_capability():
+    ctx = get_ctx()
+    ctx.caps = AllowCaps(set())
+    with pytest.raises(CapabilityError):
+        self_validate()
+
+
+def test_self_validate_without_context():
+    ctx = get_ctx()
+    clear_ctx()
+    with pytest.raises(SdkRuntimeNotInitialized):
+        self_validate()
+    set_ctx(ctx)
+
+
+def test_self_state_put_idempotent():
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.self.state"})
+    _ensure_skill(ctx, "demo_state")
+
+    result1 = self_state_put("last_run", {"ts": 1}, request_id="req-1")
+    assert result1["stored"] is True
+    assert ctx.kv.get("skills/demo_state/state/last_run") == {"ts": 1}
+
+    # Repeating with same request id should return cached result without overwriting
+    result2 = self_state_put("last_run", {"ts": 2}, request_id="req-1")
+    assert result2 == result1
+    assert ctx.kv.get("skills/demo_state/state/last_run") == {"ts": 1}
+
+    # Dry-run must not write
+    preview = self_state_put("preview", {"foo": "bar"}, request_id="dry-1", dry_run=True)
+    assert preview["stored"] is False
+    assert preview["dry_run"] is True
+    assert ctx.kv.get("skills/demo_state/state/preview") is None
+
+
+def test_self_state_get_with_default():
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.self.state"})
+    _ensure_skill(ctx, "demo_get")
+    ctx.kv.set("skills/demo_get/state/value", 42)
+
+    found = self_state_get("value")
+    missing = self_state_get("missing", default="n/a")
+
+    assert found == {"status": "ok", "key": "value", "value": 42, "found": True}
+    assert missing == {"status": "ok", "key": "missing", "value": "n/a", "found": False}
+
+
+def test_self_update_request(monkeypatch):
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.self.update"})
+    _ensure_skill(ctx, "demo_update")
+
+    def _fake_update(self, skill_id: str, dry_run: bool = False) -> SkillUpdateResult:
+        return SkillUpdateResult(updated=not dry_run, version="1.2.3")
+
+    monkeypatch.setattr(SkillUpdateService, "request_update", _fake_update)
+
+    res = self_update_request("req-up-1")
+    assert res == {"status": "ok", "updated": True, "version": "1.2.3", "dry_run": False, "request_id": "req-up-1"}
+
+    # Repeated request id returns cached result
+    assert self_update_request("req-up-1") == res
+
+    # Dry-run should not persist cached result for later real call
+    preview = self_update_request("req-up-2", dry_run=True)
+    assert preview == {"status": "ok", "updated": False, "version": "1.2.3", "dry_run": True, "request_id": "req-up-2"}
+    actual = self_update_request("req-up-2")
+    assert actual["updated"] is True
+
+
+def test_self_update_request_without_skill():
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.self.update"})
+    ctx.skill_ctx.clear()
+
+    res = self_update_request("req-no-skill")
+    assert res["status"] == "error"
+    assert res["code"] == "skill_not_selected"
+    assert res["updated"] is False

--- a/tests/sdk/test_manage_skills.py
+++ b/tests/sdk/test_manage_skills.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from adaos.domain import SkillId, SkillMeta
+from adaos.sdk.errors import CapabilityError
+from adaos.sdk.manage import skills_install, skills_list, skills_uninstall
+from adaos.services.agent_context import get_ctx
+
+
+class AllowCaps:
+    def __init__(self, allowed: set[str]):
+        self._allowed = allowed
+
+    def allows(self, capability: str) -> bool:
+        return capability in self._allowed
+
+
+@dataclass
+class FakeSkillRepo:
+    installed: dict[str, SkillMeta]
+
+    def ensure(self) -> None:
+        pass
+
+    def get(self, skill_id: str) -> SkillMeta | None:
+        return self.installed.get(skill_id)
+
+    def install(self, ref: str, *, branch: str | None = None, dest_name: str | None = None) -> SkillMeta:
+        skill_id = dest_name or ref
+        meta = SkillMeta(id=SkillId(skill_id), name=skill_id, version="1.0.0", path=f"/skills/{skill_id}")
+        self.installed[skill_id] = meta
+        return meta
+
+    def uninstall(self, skill_id: str) -> None:
+        if skill_id not in self.installed:
+            raise FileNotFoundError(skill_id)
+        del self.installed[skill_id]
+
+    def list(self) -> list[SkillMeta]:
+        return list(self.installed.values())
+
+
+@pytest.fixture
+def skill_repo():
+    ctx = get_ctx()
+    repo = FakeSkillRepo(installed={})
+    object.__setattr__(ctx, "_skills_repo", repo)
+    return repo
+
+
+def test_skills_install_dry_run(skill_repo):
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.skills.install"})
+    res = skills_install("weather", request_id="req-install", dry_run=True)
+    assert res["status"] == "ok"
+    assert res["action"] == "install"
+    assert res["dry_run"] is True
+
+
+def test_skills_install_idempotent(skill_repo):
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.skills.install"})
+    result = skills_install("weather", request_id="req-real")
+    repeat = skills_install("weather", request_id="req-real")
+    assert repeat == result
+    assert "weather" in skill_repo.installed
+
+
+def test_skills_uninstall(skill_repo):
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.skills.install", "manage.skills.uninstall"})
+    skills_install("weather", request_id="req-install2")
+
+    res = skills_uninstall("weather", request_id="req-uninstall")
+    assert res["action"] == "removed"
+    assert skills_uninstall("weather", request_id="req-uninstall") == res
+
+
+def test_skills_list(skill_repo):
+    ctx = get_ctx()
+    ctx.caps = AllowCaps({"manage.skills.list", "manage.skills.install"})
+    skills_install("one", request_id="req-one")
+    skills_install("two", request_id="req-two")
+
+    listing = skills_list()
+    ids = sorted(item["id"] for item in listing["skills"])
+    assert ids == ["one", "two"]
+
+
+def test_skills_install_missing_capability(skill_repo):
+    ctx = get_ctx()
+    ctx.caps = AllowCaps(set())
+    with pytest.raises(CapabilityError):
+        skills_install("weather", request_id="req-no-cap")


### PR DESCRIPTION
## Summary
- implement runtime helpers for capability checks, context access, and idempotent request storage used by SDK control-plane facades
- expose manage.* tools with JSON schemas plus supporting services for self state, updates, skills, scenarios, and resource requests
- document the control-plane tools and cover them with targeted SDK tests

## Testing
- PYTHONPATH=src pytest tests/sdk

------
https://chatgpt.com/codex/tasks/task_e_68cd38081e2083329f616f3c63b433fb