### PR TITLE
Add minimal scenario runtime and greet-on-boot scenario

### DIFF
--- a/.adaos/scenarios/greet_on_boot/scenario.yaml
+++ b/.adaos/scenarios/greet_on_boot/scenario.yaml
@@ -1,0 +1,56 @@
+id: greet_on_boot
+version: 0.1
+trigger: manual
+vars:
+  ask_prompt: "как к вам обращаться?"
+  greet_default: "привет!"
+steps:
+  - name: get_name
+    call: profile.get_name
+    save_as: user_name
+
+  - name: ensure_name
+    when: ${not user_name}
+    do:
+      - name: ask_for_name
+        call: io.voice.tts.speak
+        args:
+          text: ${vars.ask_prompt}
+      - name: listen_for_name
+        call: io.voice.stt.listen
+        args:
+          timeout: "20s"
+        save_as: name_answer
+      - name: store_name
+        when: ${name_answer.text}
+        call: profile.set_name
+        args:
+          name: ${name_answer.text}
+        save_as: user_name
+
+  - name: run_weather
+    call: skills.call_fs
+    args:
+      skill_dir: ".adaos/skills/weather_skill"
+      entry: "handle"
+      topic: "nlp.intent.weather.get"
+      payload: {}
+    save_as: weather
+
+  - name: compose_message
+    call: runtime.compose_greeting
+    args:
+      name: ${user_name}
+      default_greeting: ${vars.greet_default}
+      weather: ${weather.stdout}
+    save_as: msg
+
+  - name: out_console
+    call: io.console.print
+    args:
+      text: ${msg}
+
+  - name: out_voice
+    call: io.voice.tts.speak
+    args:
+      text: ${msg}

--- a/.adaos/skills/weather_skill/handler.py
+++ b/.adaos/skills/weather_skill/handler.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+from handlers.main import handle  # noqa: F401

--- a/src/adaos/services/io_console.py
+++ b/src/adaos/services/io_console.py
@@ -1,0 +1,18 @@
+"""Minimal console output adapter used by the sandbox scenario runner."""
+
+from __future__ import annotations
+
+import sys
+
+
+def print(text: str | None) -> dict[str, bool]:
+    """Write ``text`` to stdout and flush immediately."""
+
+    if text is None:
+        return {"ok": True}
+    sys.stdout.write(f"{text.rstrip()}\n")
+    sys.stdout.flush()
+    return {"ok": True}
+
+
+__all__ = ["print"]

--- a/src/adaos/services/io_console.py
+++ b/src/adaos/services/io_console.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 
 
@@ -9,6 +10,8 @@ def print(text: str | None) -> dict[str, bool]:
     """Write ``text`` to stdout and flush immediately."""
 
     if text is None:
+        return {"ok": True}
+    if os.getenv("ADAOS_TESTING"):
         return {"ok": True}
     sys.stdout.write(f"{text.rstrip()}\n")
     sys.stdout.flush()

--- a/src/adaos/services/io_voice_mock.py
+++ b/src/adaos/services/io_voice_mock.py
@@ -1,0 +1,29 @@
+"""Mock voice IO adapters (TTS/STT) for local development."""
+
+from __future__ import annotations
+
+import sys
+
+from .io_console import print as console_print
+
+
+def tts_speak(text: str | None) -> dict[str, bool]:
+    """Echo ``text`` to the console prefixed with ``[TTS]``."""
+
+    console_print(f"[TTS] {text or ''}")
+    return {"ok": True}
+
+
+def stt_listen(timeout: str = "20s") -> dict[str, str]:
+    """Read a line from stdin to emulate a STT response."""
+
+    console_print("[STT] эмуляция ввода имени: введите имя и нажмите Enter")
+    try:
+        line = sys.stdin.readline()
+    except Exception:
+        return {}
+    text = line.strip()
+    return {"text": text} if text else {}
+
+
+__all__ = ["tts_speak", "stt_listen"]

--- a/src/adaos/services/ports_registry_min.py
+++ b/src/adaos/services/ports_registry_min.py
@@ -1,0 +1,69 @@
+"""Registry of lightweight service ports used by the scenario runner."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from adaos.sdk.data import memory
+
+
+def _compose_greeting(*, name: Any, default: Any, weather: Any) -> str:
+    name_str = (str(name).strip() if name is not None else "")
+    default_str = (str(default).strip() if default is not None else "")
+    weather_str = (str(weather).strip() if weather is not None else "")
+
+    if name_str:
+        greeting = f"Привет, {name_str}!"
+    else:
+        greeting = default_str
+
+    parts = [part for part in (greeting, weather_str) if part]
+    return "\n".join(parts).strip()
+
+
+def call(route: str, args: Dict[str, Any] | None = None) -> Any:
+    args = args or {}
+
+    if route == "io.console.print":
+        from .io_console import print as fn
+
+        return fn(args.get("text"))
+
+    if route == "io.voice.tts.speak":
+        from .io_voice_mock import tts_speak as fn
+
+        return fn(args.get("text"))
+
+    if route == "io.voice.stt.listen":
+        from .io_voice_mock import stt_listen as fn
+
+        return fn(args.get("timeout", "20s"))
+
+    if route == "profile.get_name":
+        return memory.get("user.name")
+
+    if route == "profile.set_name":
+        raw = args.get("name")
+        value = str(raw).strip() if raw is not None else ""
+        if not value:
+            memory.delete("user.name")
+            return None
+        memory.put("user.name", value)
+        return value
+
+    if route == "skills.call_fs":
+        from .skills_loader_fs import call_fs
+
+        return call_fs(args)
+
+    if route == "runtime.compose_greeting":
+        return _compose_greeting(
+            name=args.get("name"),
+            default=args.get("default_greeting"),
+            weather=args.get("weather"),
+        )
+
+    raise RuntimeError(f"unknown route: {route}")
+
+
+__all__ = ["call"]

--- a/src/adaos/services/scenario_runner_min.py
+++ b/src/adaos/services/scenario_runner_min.py
@@ -1,0 +1,211 @@
+"""Minimal YAML scenario runner for the local sandbox."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict
+
+import yaml
+
+from .ports_registry_min import call as call_port
+
+_PLACEHOLDER_RE = re.compile(r"\$\{([^{}]+)\}")
+
+
+@dataclass(slots=True)
+class _InMemoryKV:
+    store: Dict[str, Any]
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        return self.store.get(key, default)
+
+    def set(self, key: str, value: Any, ttl: Any | None = None) -> None:  # noqa: D401 - signature matches kv port
+        self.store[key] = value
+
+    def delete(self, key: str) -> None:
+        self.store.pop(key, None)
+
+    def list(self, prefix: str = "") -> list[str]:
+        return [k for k in self.store if k.startswith(prefix)]
+
+
+@dataclass(slots=True)
+class _InMemorySecrets:
+    store: Dict[str, str]
+
+    def get(self, name: str) -> str | None:
+        return self.store.get(name)
+
+    def put(self, name: str, value: str) -> None:
+        self.store[name] = value
+
+
+class _FsSkillRepository:
+    def __init__(self, skills_root: Path):
+        self._root = skills_root
+
+    def get(self, skill_id: str):
+        path = (self._root / skill_id).resolve()
+        if not path.exists():
+            return None
+        return SimpleNamespace(path=path)
+
+    def list(self) -> list[Any]:  # pragma: no cover - not used but keeps interface parity
+        if not self._root.exists():
+            return []
+        return [child for child in self._root.iterdir() if child.is_dir()]
+
+
+def _ensure_agent_context(base_dir: Path) -> None:
+    from adaos.services.agent_context import AgentContext, get_ctx, set_ctx
+    from adaos.services.settings import Settings
+    from adaos.adapters.fs.path_provider import PathProvider
+    from adaos.services.eventbus import LocalEventBus
+
+    try:
+        get_ctx()
+        return
+    except RuntimeError:
+        pass
+
+    settings = Settings(base_dir=base_dir.resolve(), profile="sandbox")
+    paths = PathProvider(settings)
+    paths.ensure_tree()
+
+    kv = _InMemoryKV(store={})
+    secrets = _InMemorySecrets(store={})
+
+    ctx = AgentContext(
+        settings=settings,
+        paths=paths,
+        bus=LocalEventBus(),
+        proc=SimpleNamespace(),
+        caps=SimpleNamespace(),
+        devices=SimpleNamespace(),
+        kv=kv,
+        sql=SimpleNamespace(),
+        secrets=secrets,
+        net=SimpleNamespace(),
+        updates=SimpleNamespace(),
+        git=SimpleNamespace(),
+        fs=SimpleNamespace(),
+        sandbox=SimpleNamespace(),
+    )
+    object.__setattr__(ctx, "_skills_repo", _FsSkillRepository(paths.skills_dir()))
+    set_ctx(ctx)
+
+
+def _is_placeholder(value: str) -> bool:
+    return value.startswith("${") and value.endswith("}")
+
+
+def _resolve_reference(expr: str, bag: Dict[str, Any]) -> Any:
+    expr = expr.strip()
+    if not expr:
+        return None
+    current: Any = bag
+    for part in expr.split("."):
+        key = part.strip()
+        if key == "":
+            return None
+        if isinstance(current, dict):
+            current = current.get(key)
+        else:
+            if hasattr(current, key):
+                current = getattr(current, key)
+            else:
+                return None
+        if current is None:
+            return None
+    return current
+
+
+def _evaluate_condition(value: Any, bag: Dict[str, Any]) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str) and _is_placeholder(value):
+        inner = value[2:-1].strip()
+        if inner.startswith("not "):
+            return not bool(_resolve_reference(inner[4:], bag))
+        return bool(_resolve_reference(inner, bag))
+    if isinstance(value, str):
+        return bool(value)
+    return bool(value)
+
+
+def _substitute_string(template: str, bag: Dict[str, Any]) -> str:
+    def repl(match: re.Match[str]) -> str:
+        inner = match.group(1).strip()
+        resolved = _resolve_reference(inner, bag)
+        return "" if resolved is None else str(resolved)
+
+    return _PLACEHOLDER_RE.sub(repl, template)
+
+
+def _resolve_value(value: Any, bag: Dict[str, Any]) -> Any:
+    if isinstance(value, dict):
+        return {k: _resolve_value(v, bag) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_resolve_value(v, bag) for v in value]
+    if isinstance(value, str):
+        if _is_placeholder(value):
+            inner = value[2:-1].strip()
+            if inner.startswith("not "):
+                return bool(_resolve_reference(inner[4:], bag))
+            return _resolve_reference(inner, bag)
+        return _substitute_string(value, bag)
+    return value
+
+
+def _execute_step(step: Dict[str, Any], bag: Dict[str, Any]) -> None:
+    if not _evaluate_condition(step.get("when"), bag):
+        return
+
+    if "set" in step:
+        updates = step["set"]
+        if isinstance(updates, dict):
+            for key, value in updates.items():
+                bag[key] = _resolve_value(value, bag)
+        return
+
+    if "do" in step:
+        for sub in step.get("do", []):
+            if isinstance(sub, dict):
+                _execute_step(sub, bag)
+        return
+
+    route = step.get("call")
+    if not route:
+        return
+
+    args = _resolve_value(step.get("args") or {}, bag)
+    result = call_port(route, args)
+    save_as = step.get("save_as")
+    if save_as:
+        bag[save_as] = result
+
+
+def run_from_file(path: str) -> Dict[str, Any]:
+    scenario_path = Path(path).expanduser().resolve()
+    data = yaml.safe_load(scenario_path.read_text(encoding="utf-8")) or {}
+
+    try:
+        base_dir = scenario_path.parents[2]
+    except IndexError:
+        base_dir = scenario_path.parent
+
+    _ensure_agent_context(base_dir)
+
+    bag: Dict[str, Any] = {"vars": data.get("vars", {}) or {}}
+    for step in data.get("steps", []):
+        if isinstance(step, dict):
+            _execute_step(step, bag)
+    return bag
+
+
+__all__ = ["run_from_file"]

--- a/src/adaos/services/skills_loader_fs.py
+++ b/src/adaos/services/skills_loader_fs.py
@@ -1,0 +1,84 @@
+"""Helpers for loading skills from the local filesystem."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import sys
+import uuid
+from pathlib import Path
+
+
+def call_fs(args: dict) -> dict:
+    """Load and execute a skill handler located on the filesystem.
+
+    Args:
+        args: Mapping with keys ``skill_dir``, ``entry``, ``topic`` and ``payload``.
+    Returns:
+        A dictionary with ``result`` and captured ``stdout``.
+    """
+
+    skill_dir = Path(args["skill_dir"]).expanduser().resolve()
+    handler_py = skill_dir / "handler.py"
+    if not handler_py.exists():
+        return {"error": f"handler.py not found in {skill_dir}"}
+
+    entrypoint = args.get("entry", "handle")
+    topic = args.get("topic", "")
+    payload = args.get("payload") or {}
+
+    module_name = f"_adaos_skill_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, handler_py)
+    if spec is None or spec.loader is None:
+        return {"error": f"failed to load spec for {handler_py}"}
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    sys.path.insert(0, str(skill_dir))
+
+    skill_ctx = None
+    prev_skill = None
+    try:
+        from adaos.services.agent_context import get_ctx
+
+        try:
+            ctx = get_ctx()
+        except RuntimeError:
+            ctx = None
+        if ctx is not None:
+            skill_ctx = ctx.skill_ctx
+            prev_skill = skill_ctx.get()
+            skill_ctx.set(skill_dir.name, skill_dir)
+    except Exception:
+        skill_ctx = None
+        prev_skill = None
+    try:
+        spec.loader.exec_module(module)  # type: ignore[call-arg]
+        try:
+            fn = getattr(module, entrypoint)
+        except AttributeError:
+            return {"error": f"entry '{entrypoint}' not found in {handler_py}"}
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            result = fn(topic, payload)
+        stdout = buf.getvalue().strip()
+        return {"result": result, "stdout": stdout}
+    finally:
+        sys.modules.pop(module_name, None)
+        try:
+            sys.path.remove(str(skill_dir))
+        except ValueError:
+            pass
+        if skill_ctx is not None:
+            if prev_skill is None:
+                skill_ctx.clear()
+            else:
+                try:
+                    skill_ctx.set(prev_skill.name, prev_skill.path)
+                except Exception:
+                    skill_ctx.clear()
+
+
+__all__ = ["call_fs"]

--- a/tests/test_greet_on_boot.py
+++ b/tests/test_greet_on_boot.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+import sys
+
+from adaos.services.scenario_runner_min import run_from_file
+from adaos.sdk.data import memory
+
+SCENARIO = Path('.adaos/scenarios/greet_on_boot/scenario.yaml')
+
+
+def test_greet_with_name():
+    memory.put('user.name', 'Ада')
+
+    result = run_from_file(str(SCENARIO))
+    msg = result.get('msg')
+
+    assert isinstance(msg, str)
+    assert 'Ада' in msg
+
+    memory.delete('user.name')
+
+
+def test_greet_without_name(monkeypatch):
+    memory.delete('user.name')
+
+    monkeypatch.setattr(sys, 'stdin', StringIO('ТестИмя\n'))
+    result = run_from_file(str(SCENARIO))
+    msg = result.get('msg')
+
+    assert isinstance(msg, str)
+    assert 'ТестИмя' in msg
+
+    assert memory.get('user.name') == 'ТестИмя'

--- a/tests/test_greet_on_boot.py
+++ b/tests/test_greet_on_boot.py
@@ -7,7 +7,8 @@ import sys
 from adaos.services.scenario_runner_min import run_from_file
 from adaos.sdk.data import memory
 
-SCENARIO = Path('.adaos/scenarios/greet_on_boot/scenario.yaml')
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCENARIO = REPO_ROOT / '.adaos/scenarios/greet_on_boot/scenario.yaml'
 
 
 def test_greet_with_name():


### PR DESCRIPTION
## Summary
- add a greet_on_boot scenario that asks for a name, greets the user, and invokes the weather skill
- introduce a minimal scenario runner with supporting service adapters and port registry
- wrap the filesystem skill loader and weather skill entry point for local execution
- cover the greeting scenario with unit tests

## Testing
- PYTHONPATH=src pytest tests/test_greet_on_boot.py

------
https://chatgpt.com/codex/tasks/task_e_68cdcbefa50c833295830cc94420eb89