### PR TITLE
Add Traefik-based deployment and CI/CD for inimatic

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,85 @@
+name: inimatic CD
+
+on:
+  push:
+    branches: [rev2026]
+    paths:
+      - 'src/adaos/integrations/inimatic/**'
+      - '.github/workflows/cd.yml'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: src/adaos/integrations/inimatic
+          file: src/adaos/integrations/inimatic/deployment/backend.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/inimatic-backend:latest
+            ghcr.io/${{ github.repository_owner }}/inimatic-backend:rev2026-${{ steps.meta.outputs.short_sha }}
+          cache-from: type=gha,scope=inimatic-backend
+          cache-to: type=gha,scope=inimatic-backend,mode=max
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: src/adaos/integrations/inimatic
+          file: src/adaos/integrations/inimatic/deployment/frontend.Dockerfile
+          push: true
+          build-args: |
+            BUILD_SCRIPT=buildprod
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/inimatic-frontend:latest
+            ghcr.io/${{ github.repository_owner }}/inimatic-frontend:rev2026-${{ steps.meta.outputs.short_sha }}
+          cache-from: type=gha,scope=inimatic-frontend
+          cache-to: type=gha,scope=inimatic-frontend,mode=max
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: ${{ github.ref == 'refs/heads/rev2026' }}
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || 22 }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            REPO_DIR=${REPO_DIR:-adaos}
+            if [ ! -d "$REPO_DIR/.git" ]; then
+              git clone https://github.com/${{ github.repository }} "$REPO_DIR"
+            fi
+            cd "$REPO_DIR"
+            git fetch origin rev2026
+            git reset --hard origin/rev2026
+            cd src/adaos/integrations/inimatic
+            ./deployment/deploy.sh

--- a/src/adaos/integrations/inimatic/README.md
+++ b/src/adaos/integrations/inimatic/README.md
@@ -52,16 +52,9 @@ export PATH=${PATH}:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$GRADLE_PAT
 export PATH="$PATH:$GRADLE_PATH"
 ```
 
-## Deployment 
-```
-sudo su
-# for env deployment
-./deployment/env_deploy.sh
-# for build frontend
-./deployment/frontend_deploy.sh
-# for build backend
-./deployment/backend_deploy.sh
-```
+## Deployment
+
+See [`deployment/README.md`](deployment/README.md) for the Traefik-based Docker Compose setup, production rollout guide, and CI/CD pipeline details.
 
 ## Run Android app in development mode
 ```

--- a/src/adaos/integrations/inimatic/deployment/.env.example
+++ b/src/adaos/integrations/inimatic/deployment/.env.example
@@ -1,0 +1,24 @@
+# Docker Compose project configuration
+COMPOSE_PROJECT_NAME=inimatic
+PRODUCTION=1
+
+# Traefik ACME contact e-mail
+LE_EMAIL=admin@inimatic.com
+
+# Backend forge integration
+FORGE_GIT_URL=git@github.com:stipot-com/adaos-forge.git
+FORGE_WORKDIR=/data/forge
+FORGE_GIT_AUTHOR_NAME=AdaOS Root
+FORGE_GIT_AUTHOR_EMAIL=root@inimatic.local
+# Optional: uncomment and provide if required by forge integration
+#ROOT_TOKEN=
+#FORGE_SSH_KEY=
+
+# Frontend build configuration
+FRONTEND_BUILD_SCRIPT=buildprod
+
+# Local development certificate paths (host paths mapped into dev containers)
+DEV_CA_KEY_FILE=./deployment/dev-secrets/ca.key
+DEV_CA_CERT_FILE=./deployment/dev-secrets/ca.crt
+DEV_TLS_KEY_FILE=./deployment/dev-secrets/server.key
+DEV_TLS_CERT_FILE=./deployment/dev-secrets/server.crt

--- a/src/adaos/integrations/inimatic/deployment/Makefile
+++ b/src/adaos/integrations/inimatic/deployment/Makefile
@@ -1,0 +1,39 @@
+PROJECT_DIR := $(abspath ..)
+COMPOSE_FILE := $(PROJECT_DIR)/deployment/docker-compose.yaml
+ENV_FILE := $(PROJECT_DIR)/deployment/.env
+PROFILE ?= dev
+COMPOSE := docker compose --project-directory $(PROJECT_DIR) --env-file $(ENV_FILE) -f $(COMPOSE_FILE) --profile $(PROFILE)
+BACKEND_SERVICE := $(if $(filter $(PROFILE),prod),backend,backend-dev)
+FRONTEND_SERVICE := $(if $(filter $(PROFILE),prod),frontend,frontend-dev)
+
+.PHONY: build pull up down ps logs restart backend frontend config
+
+build:
+	$(COMPOSE) build
+
+pull:
+	$(COMPOSE) pull
+
+up:
+	$(COMPOSE) up -d --wait --remove-orphans
+
+down:
+	$(COMPOSE) down
+
+ps:
+	$(COMPOSE) ps
+
+logs:
+	$(COMPOSE) logs -f
+
+restart:
+	$(COMPOSE) restart
+
+backend:
+	$(COMPOSE) logs -f $(BACKEND_SERVICE)
+
+frontend:
+	$(COMPOSE) logs -f $(FRONTEND_SERVICE)
+
+config:
+	$(COMPOSE) config

--- a/src/adaos/integrations/inimatic/deployment/README.md
+++ b/src/adaos/integrations/inimatic/deployment/README.md
@@ -1,0 +1,77 @@
+# inimatic deployment
+
+This directory contains the production and development deployment assets for the inimatic integration.  The stack is based on Docker Compose with Traefik acting as the reverse proxy and Let's Encrypt certificate manager.
+
+## Prerequisites
+
+* A host with Docker Engine 24+ and Docker Compose v2.
+* Public DNS records that point `api.inimatic.com` and `app.inimatic.com` to the deployment host.
+* TCP ports 80 and 443 reachable from the internet (Traefik requires them for the ACME HTTP-01 challenge).
+* TLS and CA material placed on the server under `deployment/secrets/` (not committed to git).
+
+## Production deployment
+
+1. Copy `deployment/.env.example` to `deployment/.env` and adjust the values to your environment (Git forge settings, contact e-mail, optional forge credentials, etc.).
+2. Upload the TLS bundle to the server:
+   * `deployment/secrets/ca.key`
+   * `deployment/secrets/ca.crt`
+   * `deployment/secrets/server.key`
+   * `deployment/secrets/server.crt`
+   Ensure each file is owned by the deployment user and has permissions `600`.
+3. On the target host, run `docker compose --project-directory . -f deployment/docker-compose.yaml --profile prod up -d --wait` from the root of the inimatic repository or simply execute `deployment/deploy.sh`.
+4. Validate the rollout:
+   * `https://api.inimatic.com/health` should return `200 OK`.
+   * `https://app.inimatic.com/` should render the frontend with a valid Let's Encrypt certificate.
+
+Traefik stores the ACME account data and issued certificates in the `traefik_letsencrypt` Docker volume (`/letsencrypt/acme.json` inside the container).  Renewal is automatic; make sure the host has persistent Docker volumes so the store is not lost between restarts.
+
+Use the helper `Makefile` in this directory for common tasks (set `PROFILE=prod` to target production):
+
+```bash
+cd deployment
+make PROFILE=prod pull
+make PROFILE=prod up
+```
+
+## Local development (dev profile)
+
+The dev profile runs Redis, the backend, and the frontend without Traefik.  TLS assets are provided via bind mounts.  Place development certificates under `deployment/dev-secrets/` (the defaults referenced in `.env.example`) or adjust the `DEV_*` variables in `.env` to point to local files.
+
+Start the stack with:
+
+```bash
+docker compose --project-directory . -f deployment/docker-compose.yaml --profile dev up -d
+```
+
+This exposes the backend on `http://localhost:3030` and the frontend on `http://localhost:8080`.
+
+## CI/CD pipeline
+
+The GitHub Actions workflow `.github/workflows/cd.yml` builds backend and frontend images for every push to the `rev2026` branch touching inimatic sources or deployment assets.  Images are published to GHCR with the tags `latest` and `rev2026-<shortsha>` and then deployed to the production host through SSH.
+
+Configure the following repository secrets for deployment:
+
+* `DEPLOY_HOST` – public hostname or IP of the target server.
+* `DEPLOY_USER` – SSH user with permissions to pull and run the stack.
+* `DEPLOY_KEY` – private SSH key for the deployment user.
+* Optional: `DEPLOY_PORT` – non-default SSH port.
+* Optional: define `REPO_DIR` in the remote environment to override the default clone directory (`~/adaos`).
+
+The remote script fetches the latest `rev2026` branch, runs `deployment/deploy.sh`, and prints service status via `docker compose ps`.
+
+## Certificate rotation
+
+Traefik performs automatic certificate issuance and renewal via Let's Encrypt.  The ACME data (`acme.json`) resides inside the `traefik_letsencrypt` volume.  Back up this volume if the host is re-provisioned.  Manual intervention is only required when the contact e-mail or domains change.
+
+## Optional hardening
+
+For additional protection of administrative API endpoints you can enable Traefik's [basic authentication middleware](https://doc.traefik.io/traefik/middlewares/http/basicauth/) by adding a label such as `traefik.http.middlewares.api-basic.basicauth.users=<user>:<hashed-password>` to the backend service and referencing it from the router (`traefik.http.routers.api.middlewares=api-sec@docker,api-rl@docker,api-basic@docker`).
+
+## Troubleshooting
+
+| Symptom | Possible cause | Suggested action |
+| ------- | -------------- | ---------------- |
+| Let's Encrypt fails to issue certificates | Ports 80/443 blocked, DNS not pointing at host, or previous certificates exhausted the rate limit | Ensure DNS is correct, open ports on firewalls, and wait before retrying when LE rate limits hit. |
+| Frontend/API unreachable | Containers unhealthy or Traefik not running | Check `docker compose ps`, inspect logs with `docker compose logs <service>`; validate secrets and `.env` values. |
+| ACME storage errors | `traefik_letsencrypt` volume missing or not writable | Remove the container and recreate, ensuring the volume is intact. |
+| Port conflicts on startup | Other services listening on 80/443 | Stop conflicting services or adjust host port mappings in the compose file (not recommended for production). |

--- a/src/adaos/integrations/inimatic/deployment/backend.Dockerfile
+++ b/src/adaos/integrations/inimatic/deployment/backend.Dockerfile
@@ -5,5 +5,5 @@ COPY ./package*.json /inimatic_backend
 RUN npm install --force
 COPY ./backend /inimatic_backend/backend
 RUN npm run build:api
-EXPOSE 3031
+EXPOSE 3030
 CMD ["npm", "run", "serve:api"]

--- a/src/adaos/integrations/inimatic/deployment/deploy.sh
+++ b/src/adaos/integrations/inimatic/deployment/deploy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-inimatic}"
+COMPOSE_ARGS=(
+  --project-directory "$ROOT_DIR"
+  --env-file "$ROOT_DIR/deployment/.env"
+  -f "$ROOT_DIR/deployment/docker-compose.yaml"
+  --profile prod
+)
+
+docker compose "${COMPOSE_ARGS[@]}" pull || true
+docker compose "${COMPOSE_ARGS[@]}" up -d --remove-orphans --wait
+docker compose "${COMPOSE_ARGS[@]}" ps

--- a/src/adaos/integrations/inimatic/deployment/docker-compose.yaml
+++ b/src/adaos/integrations/inimatic/deployment/docker-compose.yaml
@@ -1,89 +1,222 @@
-# docker-compose.yaml
+version: "3.9"
+
 services:
-    redis:
-        image: redis:latest
-        healthcheck:
-            test: ["CMD", "redis-cli", "ping"]
-            interval: 1s
-            timeout: 3s
-            retries: 5
-        command: ["redis-server"]
-    backend:
-        depends_on:
-            redis:
-                condition: service_healthy
-        build:
-            context: .
-            dockerfile: ./deployment/backend.Dockerfile
-        restart: always
-        environment:
-            - PORT=3031
-        ports:
-            - "3031:3031"
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server"]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+    networks:
+      - internal
 
-    frontend:
-        depends_on:
-            backend:
-                condition: service_started
-        build:
-            context: .
-            dockerfile: ./deployment/frontend.Dockerfile
-            args:
-                BUILD_SCRIPT: ${BUILD_SCRIPT}
-                BASE_DOMAIN: ${BASE_DOMAIN}
-        restart: always
-        environment:
-            - BUILD_SCRIPT=${BUILD_SCRIPT}
-        ports:
-            - "8081:8081"
-        configs:
-            - source: nginx-dev-server
-              target: /etc/nginx/conf.d/default.conf
-    nginx:
-        image: umputun/nginx-le:latest
-        hostname: nginx
-        restart: always
-        container_name: nginx
-        depends_on:
-            frontend:
-                condition: service_started # service_healthy
-        volumes:
-            - ./deployment/etc/ssl:/etc/nginx/ssl
-            - type: bind
-              source: ./deployment/etc/service.conf
-              target: /etc/nginx/service.conf
+  traefik:
+    profiles: ["prod"]
+    image: traefik:v3.1
+    restart: unless-stopped
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --providers.docker.network=proxy
+      - --entrypoints.web.address=:80
+      - --entrypoints.websecure.address=:443
+      - --entrypoints.web.http.redirections.entryPoint.to=websecure
+      - --entrypoints.web.http.redirections.entryPoint.scheme=https
+      - --certificatesresolvers.le.acme.email=${LE_EMAIL}
+      - --certificatesresolvers.le.acme.storage=/letsencrypt/acme.json
+      - --certificatesresolvers.le.acme.httpchallenge.entrypoint=web
+      - --api.dashboard=true
+      - --accesslog=true
+      - --accesslog.format=json
+      - --log.format=json
+      - --log.level=INFO
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - traefik_letsencrypt:/letsencrypt
+    networks:
+      - proxy
 
-        ports:
-            - "80:80"
-            - "443:443"
-            - "3000:3000"
-        environment:
-            - TZ=Europe/Moscow
-            - LETSENCRYPT=true
-            - LE_EMAIL=connect@stipot.com
-            - LE_FQDN=ru.inimatic.com
+  backend:
+    profiles: ["prod"]
+    image: ghcr.io/stipot-com/inimatic-backend:latest
+    restart: unless-stopped
+    depends_on:
+      redis:
+        condition: service_healthy
+    expose:
+      - "3030"
+    environment:
+      PORT: "3030"
+      PRODUCTION: ${PRODUCTION:-1}
+      FORGE_GIT_URL: ${FORGE_GIT_URL}
+      FORGE_WORKDIR: ${FORGE_WORKDIR}
+      FORGE_GIT_AUTHOR_NAME: ${FORGE_GIT_AUTHOR_NAME}
+      FORGE_GIT_AUTHOR_EMAIL: ${FORGE_GIT_AUTHOR_EMAIL}
+      CA_KEY_PEM_FILE: /run/secrets/ca_key
+      CA_CERT_PEM_FILE: /run/secrets/ca_crt
+      TLS_KEY_PEM_FILE: /run/secrets/tls_key
+      TLS_CERT_PEM_FILE: /run/secrets/tls_crt
+      ROOT_TOKEN: ${ROOT_TOKEN:-}
+      FORGE_SSH_KEY: ${FORGE_SSH_KEY:-}
+    secrets:
+      - ca_key
+      - ca_crt
+      - tls_key
+      - tls_crt
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:3030/health || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 20s
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.api.rule=Host(`api.inimatic.com`)
+      - traefik.http.routers.api.entrypoints=websecure
+      - traefik.http.routers.api.tls.certresolver=le
+      - traefik.http.services.api.loadbalancer.server.port=3030
+      - traefik.http.routers.api.middlewares=api-sec@docker,api-rl@docker
+      - traefik.http.middlewares.api-sec.headers.stsSeconds=63072000
+      - traefik.http.middlewares.api-sec.headers.stsIncludeSubdomains=true
+      - traefik.http.middlewares.api-sec.headers.stsPreload=true
+      - traefik.http.middlewares.api-sec.headers.contentTypeNosniff=true
+      - traefik.http.middlewares.api-sec.headers.browserXssFilter=true
+      - traefik.http.middlewares.api-sec.headers.customFrameOptionsValue=SAMEORIGIN
+      - traefik.http.middlewares.api-sec.headers.referrerPolicy=no-referrer
+      - traefik.http.middlewares.api-rl.ratelimit.average=20
+      - traefik.http.middlewares.api-rl.ratelimit.burst=40
+    networks:
+      - internal
+      - proxy
+
+  frontend:
+    profiles: ["prod"]
+    image: ghcr.io/stipot-com/inimatic-frontend:latest
+    restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_healthy
+    expose:
+      - "8080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/ || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 20s
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.app.rule=Host(`app.inimatic.com`)
+      - traefik.http.routers.app.entrypoints=websecure
+      - traefik.http.routers.app.tls.certresolver=le
+      - traefik.http.services.app.loadbalancer.server.port=8080
+      - traefik.http.routers.app.middlewares=app-sec@docker
+      - traefik.http.middlewares.app-sec.headers.stsSeconds=63072000
+      - traefik.http.middlewares.app-sec.headers.stsIncludeSubdomains=true
+      - traefik.http.middlewares.app-sec.headers.stsPreload=true
+      - traefik.http.middlewares.app-sec.headers.contentTypeNosniff=true
+      - traefik.http.middlewares.app-sec.headers.browserXssFilter=true
+      - traefik.http.middlewares.app-sec.headers.customFrameOptionsValue=SAMEORIGIN
+      - traefik.http.middlewares.app-sec.headers.referrerPolicy=no-referrer
+    networks:
+      - proxy
+
+  backend-dev:
+    profiles: ["dev"]
+    build:
+      context: .
+      dockerfile: ./deployment/backend.Dockerfile
+    restart: unless-stopped
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      PORT: "3030"
+      PRODUCTION: ${PRODUCTION:-1}
+      FORGE_GIT_URL: ${FORGE_GIT_URL}
+      FORGE_WORKDIR: ${FORGE_WORKDIR}
+      FORGE_GIT_AUTHOR_NAME: ${FORGE_GIT_AUTHOR_NAME}
+      FORGE_GIT_AUTHOR_EMAIL: ${FORGE_GIT_AUTHOR_EMAIL}
+      CA_KEY_PEM_FILE: /secrets/dev/ca.key
+      CA_CERT_PEM_FILE: /secrets/dev/ca.crt
+      TLS_KEY_PEM_FILE: /secrets/dev/tls.key
+      TLS_CERT_PEM_FILE: /secrets/dev/tls.crt
+      ROOT_TOKEN: ${ROOT_TOKEN:-}
+      FORGE_SSH_KEY: ${FORGE_SSH_KEY:-}
+    volumes:
+      - type: bind
+        source: ${DEV_CA_KEY_FILE:-./deployment/dev-secrets/ca.key}
+        target: /secrets/dev/ca.key
+        read_only: true
+      - type: bind
+        source: ${DEV_CA_CERT_FILE:-./deployment/dev-secrets/ca.crt}
+        target: /secrets/dev/ca.crt
+        read_only: true
+      - type: bind
+        source: ${DEV_TLS_KEY_FILE:-./deployment/dev-secrets/server.key}
+        target: /secrets/dev/tls.key
+        read_only: true
+      - type: bind
+        source: ${DEV_TLS_CERT_FILE:-./deployment/dev-secrets/server.crt}
+        target: /secrets/dev/tls.crt
+        read_only: true
+    ports:
+      - "3030:3030"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:3030/health || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 20s
+    networks:
+      - internal
+
+  frontend-dev:
+    profiles: ["dev"]
+    build:
+      context: .
+      dockerfile: ./deployment/frontend.Dockerfile
+      args:
+        BUILD_SCRIPT: ${FRONTEND_BUILD_SCRIPT:-build}
+    restart: unless-stopped
+    depends_on:
+      backend-dev:
+        condition: service_healthy
+    environment:
+      BUILD_SCRIPT: ${FRONTEND_BUILD_SCRIPT:-build}
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/ || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 20s
+    networks:
+      - internal
+
+secrets:
+  ca_key:
+    file: ./deployment/secrets/ca.key
+  ca_crt:
+    file: ./deployment/secrets/ca.crt
+  tls_key:
+    file: ./deployment/secrets/server.key
+  tls_crt:
+    file: ./deployment/secrets/server.crt
 
 volumes:
-    cert_volume: {}
-    acme_challenge: {}
+  traefik_letsencrypt: {}
 
-configs:
-    nginx-dev-server:
-        content: |
-            server {
-              listen 8081;
-              server_name frontend;
-              charset utf-8;
-              client_max_body_size 10M;
-              root /usr/share/nginx/html;
-              index index.html index.htm;
-
-              location / {
-                try_files $$uri $$uri/ /index.html;
-              }
-
-              error_page 500 502 503 504 /502.html;
-              location = /50x.html {
-                internal;
-              }
-            }
+networks:
+  proxy:
+    driver: bridge
+  internal:
+    driver: bridge

--- a/src/adaos/integrations/inimatic/deployment/frontend.Dockerfile
+++ b/src/adaos/integrations/inimatic/deployment/frontend.Dockerfile
@@ -7,4 +7,5 @@ COPY ./ /inimatic
 RUN npm run ${BUILD_SCRIPT}
 FROM nginx:latest
 COPY --from=build /inimatic/www /usr/share/nginx/html
-EXPOSE 8081
+COPY ./deployment/nginx/default.conf /etc/nginx/conf.d/default.conf
+EXPOSE 8080

--- a/src/adaos/integrations/inimatic/deployment/nginx/default.conf
+++ b/src/adaos/integrations/inimatic/deployment/nginx/default.conf
@@ -1,0 +1,23 @@
+server {
+    listen 8080;
+    server_name _;
+    charset utf-8;
+    client_max_body_size 10m;
+
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location = /health {
+        add_header Content-Type text/plain;
+        return 200 'ok';
+    }
+
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        internal;
+    }
+}

--- a/src/adaos/integrations/inimatic/deployment/secrets/.gitignore
+++ b/src/adaos/integrations/inimatic/deployment/secrets/.gitignore
@@ -1,0 +1,3 @@
+# All TLS/CA material must be provided out-of-band.
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- replace the inimatic docker-compose stack with Traefik, production/dev profiles, health checks, and Docker secrets
- add deployment helper assets including .env example, Makefile, deploy script, and detailed README
- publish backend/frontend images to GHCR via GitHub Actions and deploy over SSH to the production host

## Testing
- not run (docker is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d283a481bc83328613f44846fc5e0e