### PR TITLE
Restore Socket.IO compatibility with AdaOS proxy

### DIFF
--- a/src/adaos/integrations/inimatic/backend/adaos-bridge.ts
+++ b/src/adaos/integrations/inimatic/backend/adaos-bridge.ts
@@ -2,70 +2,93 @@
 import express, { type Express, type Request } from 'express'
 import type http from 'http'
 import { createProxyMiddleware } from 'http-proxy-middleware'
+import { parse } from 'node:url'
 
 const DEFAULT_BASE = process.env['ADAOS_BASE'] ?? 'http://127.0.0.1:8777'
 const DEFAULT_TOKEN = process.env['ADAOS_TOKEN'] ?? 'dev-local-token'
+const ADAOS_PROXY_ENABLED = process.env['ADAOS_PROXY_ENABLED'] !== '0'
+const ADAOS_PROXY_UPGRADE_PREFIXES = (process.env['ADAOS_PROXY_UPGRADE_PREFIXES'] ?? '/adaos')
+        .split(',')
+        .map((prefix) => prefix.trim())
+        .filter((prefix) => prefix.length > 0)
 
 const resolveToken = (req: Request) => (req.header('X-AdaOS-Token') ?? DEFAULT_TOKEN) as string
 const resolveBase = (req: Request) => (req.header('X-AdaOS-Base') ?? DEFAULT_BASE) as string
 
 export function installAdaosBridge(app: Express, server: http.Server) {
-	// body parser
-	app.use(express.json())
+        // body parser
+        app.use(express.json())
 
-	// /adaos/** → прокси на ноду AdaOS (HTTP+WS)
-	const adaosProxy = createProxyMiddleware({
-		target: DEFAULT_BASE,
-		changeOrigin: true,
-		ws: true,
-		pathRewrite: { '^/adaos': '' },
-		router: (req) => resolveBase(req as Request),
-		on: {
-			proxyReq: (proxyReq, req) => {
-				proxyReq.setHeader('X-AdaOS-Token', resolveToken(req as Request))
-			},
-		},
-	})
+        if (ADAOS_PROXY_ENABLED) {
+                // /adaos/** → прокси на ноду AdaOS (HTTP+WS)
+                const adaosProxy = createProxyMiddleware({
+                        target: DEFAULT_BASE,
+                        changeOrigin: true,
+                        ws: true,
+                        pathRewrite: { '^/adaos': '' },
+                        router: (req) => resolveBase(req as Request),
+                        on: {
+                                proxyReq: (proxyReq, req) => {
+                                        proxyReq.setHeader('X-AdaOS-Token', resolveToken(req as Request))
+                                },
+                        },
+                })
 
-	app.use('/adaos', adaosProxy)
-	server.on('upgrade', (req, socket, head) => {
-		// @ts-ignore: у middleware есть upgrade
-		adaosProxy.upgrade?.(req, socket, head)
-	})
+                app.use('/adaos', adaosProxy)
+                if (ADAOS_PROXY_UPGRADE_PREFIXES.length > 0) {
+                        server.on('upgrade', (req, socket, head) => {
+                                const { pathname = '' } = parse(req.url ?? '')
+                                const shouldProxy = ADAOS_PROXY_UPGRADE_PREFIXES.some((prefix) =>
+                                        pathname.startsWith(prefix),
+                                )
+                                if (!shouldProxy) {
+                                        return
+                                }
+                                // @ts-ignore: у middleware есть upgrade
+                                adaosProxy.upgrade?.(req, socket, head)
+                        })
+                }
 
-	// «короткие» HUB-ручки
-	app.get('/api/subnet/nodes', async (req, res) => {
-		try {
-			const r = await fetch(`${resolveBase(req)}/api/subnet/nodes`, {
-				headers: { 'X-AdaOS-Token': resolveToken(req) },
-			})
-			if (!r.ok) throw new Error(String(r.status))
-			res.json(await r.json())
-		} catch (e: any) {
-			res.status(502).json({ error: 'adaos upstream failed', detail: String(e?.message ?? e) })
-		}
-	})
+                // «короткие» HUB-ручки
+                app.get('/api/subnet/nodes', async (req, res) => {
+                        try {
+                                const r = await fetch(`${resolveBase(req)}/api/subnet/nodes`, {
+                                        headers: { 'X-AdaOS-Token': resolveToken(req) },
+                                })
+                                if (!r.ok) throw new Error(String(r.status))
+                                res.json(await r.json())
+                        } catch (e: any) {
+                                res.status(502).json({
+                                        error: 'adaos upstream failed',
+                                        detail: String(e?.message ?? e),
+                                })
+                        }
+                })
 
-	app.post('/api/subnet/ping', async (req, res) => {
-		try {
-			const r = await fetch(`${resolveBase(req)}/api/subnet/ping`, {
-				method: 'POST',
-				headers: {
-					'content-type': 'application/json',
-					'X-AdaOS-Token': resolveToken(req),
-				},
-				body: JSON.stringify(req.body ?? {}),
-			})
-			if (!r.ok) throw new Error(String(r.status))
-			res.json(await r.json())
-		} catch (e: any) {
-			res.status(502).json({ error: 'adaos upstream failed', detail: String(e?.message ?? e) })
-		}
-	})
+                app.post('/api/subnet/ping', async (req, res) => {
+                        try {
+                                const r = await fetch(`${resolveBase(req)}/api/subnet/ping`, {
+                                        method: 'POST',
+                                        headers: {
+                                                'content-type': 'application/json',
+                                                'X-AdaOS-Token': resolveToken(req),
+                                        },
+                                        body: JSON.stringify(req.body ?? {}),
+                                })
+                                if (!r.ok) throw new Error(String(r.status))
+                                res.json(await r.json())
+                        } catch (e: any) {
+                                res.status(502).json({
+                                        error: 'adaos upstream failed',
+                                        detail: String(e?.message ?? e),
+                                })
+                        }
+                })
+        }
 
-	// health
-	app.get('/healthz', (_req, res) =>
-		res.json({ ok: true, adaos: DEFAULT_BASE, time: new Date().toISOString() })
-	)
+        // health
+        app.get('/healthz', (_req, res) =>
+                res.json({ ok: true, adaos: DEFAULT_BASE, time: new Date().toISOString() })
+        )
 }
 


### PR DESCRIPTION
## Summary
- gate AdaOS proxy upgrades behind configurable prefixes and disable flag so /socket.io upgrades fall through
- configure Socket.IO server path, upgrade auth gating, and namespace registration to preserve legacy clients while enabling new /adaos channel

## Testing
- Not run (node dependencies not installed in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e17baa797083328a445f3338406007